### PR TITLE
[DEV-312] Take in account subnetwork's GAS limit, when adding

### DIFF
--- a/mining/mining.go
+++ b/mining/mining.go
@@ -488,7 +488,7 @@ func (g *BlkTmplGenerator) NewBlockTemplate(payToAddress util.Address) (*BlockTe
 			if !ok {
 				gasUsage = 0
 			}
-			gasLimit, err := blockdag.GasLimit(subnetwork)
+			gasLimit, err := g.dag.GasLimit(subnetwork)
 			if err != nil {
 				log.Errorf("Cannot get GAS limit for subnetwork %v", subnetwork)
 				continue


### PR DESCRIPTION
Please add ticket to create unit test for validate.go.CheckTransactionSanity. Cannot write test untill dag.GetGasLimit implemented.