### PR TITLE
Fixing missing "pkg/errors" import

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -9,7 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
+	"pkg/errors"
+	
 	"github.com/btcsuite/winsvc/eventlog"
 	"github.com/btcsuite/winsvc/mgr"
 	"github.com/btcsuite/winsvc/svc"


### PR DESCRIPTION
This is breaking the windows build. 