### PR TITLE
[NOD-1093] Add hashMerkleRoot to GetBlockTemplateResult

### DIFF
--- a/cmd/kaspaminer/mineloop.go
+++ b/cmd/kaspaminer/mineloop.go
@@ -179,7 +179,7 @@ func solveLoop(newTemplateChan chan *rpcmodel.GetBlockTemplateResult, foundBlock
 		}
 
 		stopOldTemplateSolving = make(chan struct{})
-		block, err := rpcclient.ParseBlock(template)
+		block, err := rpcclient.ConvertGetBlockTemplateResultToBlock(template)
 		if err != nil {
 			errChan <- errors.Errorf("Error parsing block: %s", err)
 			return

--- a/rpcclient/mining.go
+++ b/rpcclient/mining.go
@@ -106,14 +106,14 @@ func (c *Client) GetBlockTemplate(payAddress string, longPollID string) (*rpcmod
 	return c.GetBlockTemplateAsync(payAddress, longPollID).Receive()
 }
 
-// ParseBlock Accepts a GetBlockTemplateResult and parse it into a Block
-func ParseBlock(template *rpcmodel.GetBlockTemplateResult) (*util.Block, error) {
+// ConvertGetBlockTemplateResultToBlock Accepts a GetBlockTemplateResult and parses it into a Block
+func ConvertGetBlockTemplateResultToBlock(template *rpcmodel.GetBlockTemplateResult) (*util.Block, error) {
 	// parse parent hashes
 	parentHashes := make([]*daghash.Hash, len(template.ParentHashes))
 	for i, parentHash := range template.ParentHashes {
 		hash, err := daghash.NewHashFromStr(parentHash)
 		if err != nil {
-			return nil, errors.Errorf("Error decoding hash %s: %s", parentHash, err)
+			return nil, errors.Wrapf(err, "error decoding hash: '%s'", parentHash)
 		}
 		parentHashes[i] = hash
 	}
@@ -121,24 +121,24 @@ func ParseBlock(template *rpcmodel.GetBlockTemplateResult) (*util.Block, error) 
 	// parse Bits
 	bitsUint64, err := strconv.ParseUint(template.Bits, 16, 32)
 	if err != nil {
-		return nil, errors.Errorf("Error decoding bits %s: %s", template.Bits, err)
+		return nil, errors.Wrapf(err, "error decoding bits: '%s'", template.Bits)
 	}
 	bits := uint32(bitsUint64)
 
 	// parse hashMerkleRoot
 	hashMerkleRoot, err := daghash.NewHashFromStr(template.HashMerkleRoot)
 	if err != nil {
-		return nil, errors.Errorf("Error parsing HashMerkleRoot: %s", err)
+		return nil, errors.Wrapf(err, "error parsing HashMerkleRoot: '%s'", template.HashMerkleRoot)
 	}
 
-	// parseAcceptedIDMerkleRoot
+	// parse AcceptedIDMerkleRoot
 	acceptedIDMerkleRoot, err := daghash.NewHashFromStr(template.AcceptedIDMerkleRoot)
 	if err != nil {
-		return nil, errors.Errorf("Error parsing acceptedIDMerkleRoot: %s", err)
+		return nil, errors.Wrapf(err, "error parsing acceptedIDMerkleRoot: '%s'", template.AcceptedIDMerkleRoot)
 	}
 	utxoCommitment, err := daghash.NewHashFromStr(template.UTXOCommitment)
 	if err != nil {
-		return nil, errors.Errorf("Error parsing utxoCommitment: %s", err)
+		return nil, errors.Wrapf(err, "error parsing utxoCommitment '%s'", template.UTXOCommitment)
 	}
 	// parse rest of block
 	msgBlock := wire.NewMsgBlock(
@@ -149,7 +149,7 @@ func ParseBlock(template *rpcmodel.GetBlockTemplateResult) (*util.Block, error) 
 		reader := hex.NewDecoder(strings.NewReader(txResult.Data))
 		tx := &wire.MsgTx{}
 		if err := tx.KaspaDecode(reader, 0); err != nil {
-			return nil, errors.Errorf("Error decoding tx #%d: %s", i, err)
+			return nil, errors.Wrapf(err, "error decoding tx #%d", i)
 		}
 		msgBlock.AddTransaction(tx)
 	}

--- a/rpcmodel/rpc_results.go
+++ b/rpcmodel/rpc_results.go
@@ -141,6 +141,7 @@ type GetBlockTemplateResult struct {
 	ParentHashes         []string                   `json:"parentHashes"`
 	MassLimit            int64                      `json:"massLimit,omitempty"`
 	Transactions         []GetBlockTemplateResultTx `json:"transactions"`
+	HashMerkleRoot       string                     `json:"hashMerkleRoot"`
 	AcceptedIDMerkleRoot string                     `json:"acceptedIdMerkleRoot"`
 	UTXOCommitment       string                     `json:"utxoCommitment"`
 	Version              int32                      `json:"version"`

--- a/server/rpc/handle_get_block_template.go
+++ b/server/rpc/handle_get_block_template.go
@@ -716,6 +716,7 @@ func (state *gbtWorkState) blockTemplateResult(s *Server) (*rpcmodel.GetBlockTem
 		ParentHashes:         daghash.Strings(header.ParentHashes),
 		MassLimit:            wire.MaxMassPerBlock,
 		Transactions:         transactions,
+		HashMerkleRoot:       header.HashMerkleRoot.String(),
 		AcceptedIDMerkleRoot: header.AcceptedIDMerkleRoot.String(),
 		UTXOCommitment:       header.UTXOCommitment.String(),
 		Version:              header.Version,

--- a/server/rpc/rpcserverhelp.go
+++ b/server/rpc/rpcserverhelp.go
@@ -313,6 +313,7 @@ var helpDescsEnUS = map[string]string{
 	"getBlockTemplateResult-sigOpLimit":           "Number of sigops allowed in blocks",
 	"getBlockTemplateResult-massLimit":            "Max transaction mass allowed in blocks",
 	"getBlockTemplateResult-transactions":         "Array of transactions as JSON objects",
+	"getBlockTemplateResult-hashMerkleRoot":       "The root of the merkle tree of all transaction IDs in this block",
 	"getBlockTemplateResult-acceptedIdMerkleRoot": "The root of the merkle tree of transaction IDs accepted by this block",
 	"getBlockTemplateResult-utxoCommitment":       "An ECMH UTXO commitment of this block",
 	"getBlockTemplateResult-version":              "The block version",


### PR DESCRIPTION
Hi,
I added `hashMerkleRoot` to the getBlockTemplate result,
This allows a miner to reconstruct the header without reconstructing the merkle tree.

The next commit removes the merkle tree reconstruction from kaspaminer
and the one after it moves `ParseBlock` into rpcclient, so that other go based miners could use it (as it is necessary for every miner), if there's a better place for it tell me and I'll move it.

(Reviewing commit by commit should make this very easy, the 2 first commits change logic, and the last one just moves the function)