### PR TITLE
[NOD-1101] Hash data without serializing into a buffer first

### DIFF
--- a/domainmessage/bench_test.go
+++ b/domainmessage/bench_test.go
@@ -411,3 +411,21 @@ func BenchmarkDoubleHashH(b *testing.B) {
 		_ = daghash.DoubleHashH(txBytes)
 	}
 }
+
+// BenchmarkDoubleHashWriter performs a benchmark on how long it takes to perform
+// a double hash via the writer returning a daghash.Hash.
+func BenchmarkDoubleHashWriter(b *testing.B) {
+	var buf bytes.Buffer
+	err := genesisCoinbaseTx.Serialize(&buf)
+	if err != nil {
+		b.Fatalf("Serialize: unexpected error: %+v", err)
+	}
+	txBytes := buf.Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		writer := daghash.NewDoubleHashWriter()
+		_, _ = writer.Write(txBytes)
+		writer.Finalize()
+	}
+}

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -192,7 +192,8 @@ func (p *poolHarness) CreateSignedTxForSubnetwork(inputs []spendableOutpoint, nu
 		})
 	}
 
-	tx := domainmessage.NewSubnetworkMsgTx(domainmessage.TxVersion, txIns, txOuts, subnetworkID, gas, []byte{})
+	// Payload must be nil because it might be the native subnetwork
+	tx := domainmessage.NewSubnetworkMsgTx(domainmessage.TxVersion, txIns, txOuts, subnetworkID, gas, nil)
 
 	// Sign the new transaction.
 	for i := range tx.TxIn {

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -364,10 +364,10 @@ func calcSignatureHash(script []parsedOpcode, hashType SigHashType, tx *domainme
 	// The final hash is the double sha256 of both the serialized modified
 	// transaction and the hash type (encoded as a 4-byte little-endian
 	// value) appended.
-	wbuf := bytes.NewBuffer(make([]byte, 0, txCopy.SerializeSize()+4))
-	txCopy.Serialize(wbuf)
-	binary.Write(wbuf, binary.LittleEndian, hashType)
-	hash := daghash.DoubleHashH(wbuf.Bytes())
+	writer := daghash.NewDoubleHashWriter()
+	txCopy.Serialize(writer)
+	binary.Write(writer, binary.LittleEndian, hashType)
+	hash := writer.Finalize()
 	return &hash, nil
 }
 

--- a/util/daghash/hashfuncs_test.go
+++ b/util/daghash/hashfuncs_test.go
@@ -68,6 +68,35 @@ func TestHashFuncs(t *testing.T) {
 			t.Errorf("HashH(%q) = %s, want %s", test.in, h, test.out)
 			continue
 		}
+		writer := NewHashWriter()
+		n, err := writer.Write([]byte(test.in))
+		if err != nil || n != len(test.in) {
+			t.Fatalf("This should never fail, n expected: '%d', found: '%d'. err: '%+v'.", n, len(test.in), err)
+		}
+		hash = writer.Finalize()
+		h = fmt.Sprintf("%x", hash[:])
+		if h != test.out {
+			t.Fatalf("Finalize(%q) = %s, want %s", test.in, h, test.out)
+		}
+
+		// Test that writing the input part by part still results in the same hash.
+		writer = NewHashWriter()
+		slice := []byte(test.in)[:len(test.in)/2]
+		n, err = writer.Write(slice)
+		if err != nil || n != len(slice) {
+			t.Fatalf("This should never fail, n expected: '%d', found: '%d'. err: '%+v'.", n, len(slice), err)
+		}
+		slice = []byte(test.in)[len(test.in)/2:]
+		n, err = writer.Write([]byte(test.in)[len(test.in)/2:])
+		if err != nil || n != len(slice) {
+			t.Fatalf("This should never fail, n expected: '%d', found: '%d'. err: '%+v'.", n, len(slice), err)
+		}
+		hash = writer.Finalize()
+		h = fmt.Sprintf("%x", hash[:])
+		if h != test.out {
+			t.Errorf("Finalize(%q) = %s, want %s", test.in, h, test.out)
+			continue
+		}
 	}
 }
 
@@ -130,6 +159,36 @@ func TestDoubleHashFuncs(t *testing.T) {
 		if h != test.out {
 			t.Errorf("DoubleHashH(%q) = %s, want %s", test.in, h,
 				test.out)
+			continue
+		}
+		writer := NewDoubleHashWriter()
+		n, err := writer.Write([]byte(test.in))
+		if err != nil || n != len(test.in) {
+			t.Fatalf("This should never fail, n expected: '%d', found: '%d'. err: '%+v'.", n, len(test.in), err)
+		}
+		hash = writer.Finalize()
+		h = fmt.Sprintf("%x", hash[:])
+		if h != test.out {
+			t.Errorf("Finalize(%q) = %s, want %s", test.in, h, test.out)
+			continue
+		}
+
+		// Test that writing the input part by part still results in the same hash.
+		writer = NewDoubleHashWriter()
+		slice := []byte(test.in)[:len(test.in)/2]
+		n, err = writer.Write(slice)
+		if err != nil || n != len(slice) {
+			t.Fatalf("This should never fail, n expected: '%d', found: '%d'. err: '%+v'.", n, len(slice), err)
+		}
+		slice = []byte(test.in)[len(test.in)/2:]
+		n, err = writer.Write([]byte(test.in)[len(test.in)/2:])
+		if err != nil || n != len(slice) {
+			t.Fatalf("This should never fail, n expected: '%d', found: '%d'. err: '%+v'.", n, len(slice), err)
+		}
+		hash = writer.Finalize()
+		h = fmt.Sprintf("%x", hash[:])
+		if h != test.out {
+			t.Errorf("Finalize(%q) = %s, want %s", test.in, h, test.out)
 			continue
 		}
 	}

--- a/util/daghash/hashwriters.go
+++ b/util/daghash/hashwriters.go
@@ -1,0 +1,58 @@
+package daghash
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+)
+
+// HashWriter is used to incrementally hash data without concatenating all of the data to a single buffer
+// it exposes an io.Writer api and a Finalize function to get the resulting hash.
+// HashWriter.Write(slice).Finalize == HashH(slice)
+type HashWriter struct {
+	inner hash.Hash
+}
+
+// DoubleHashWriter is used to incrementally double hash data without concatenating all of the data to a single buffer
+// it exposes an io.Writer api and a Finalize function to get the resulting hash.
+// DoubleHashWriter.Write(slice).Finalize == DoubleHashH(slice)
+type DoubleHashWriter struct {
+	inner hash.Hash
+}
+
+// NewHashWriter returns a new Hash Writer
+func NewHashWriter() *HashWriter {
+	return &HashWriter{sha256.New()}
+}
+
+// Write will always return (len(p), nil)
+func (h *HashWriter) Write(p []byte) (n int, err error) {
+	return h.inner.Write(p)
+}
+
+// Finalize returns the resulting hash
+func (h *HashWriter) Finalize() Hash {
+	res := Hash{}
+	// Can never happen, Sha256's Sum is 32 bytes.
+	err := res.SetBytes(h.inner.Sum(nil))
+	if err != nil {
+		panic(fmt.Sprintf("Should never fail, sha256.Sum is 32 bytes and so is daghash.Hash: '%+v'", err))
+	}
+	return res
+}
+
+// NewDoubleHashWriter Returns a new DoubleHashWriter
+func NewDoubleHashWriter() *DoubleHashWriter {
+	return &DoubleHashWriter{sha256.New()}
+}
+
+// Write will always return (len(p), nil)
+func (h *DoubleHashWriter) Write(p []byte) (n int, err error) {
+	return h.inner.Write(p)
+}
+
+// Finalize returns the resulting double hash
+func (h *DoubleHashWriter) Finalize() Hash {
+	firstHashInTheSum := h.inner.Sum(nil)
+	return sha256.Sum256(firstHashInTheSum)
+}


### PR DESCRIPTION
Hi,
Right now we serialize txs/blocks into a buffer before hashing, this is slower and takes a lot of memory.
While hash functions are built to be incremental, so I added a Hash and DoubleHash Writers that implement `io.Writer` so that we can use those when serializing+hashing.

I replaced the usages that I've found, there are probably others I've missed.

Sadly I don't have a good benchmark on hand to prove it improves performance, but at the very least it should improve memory usage.