### PR TITLE
[NOD-1316] Refactor TestGHOSTDAG to enable arbitrary DAGs

### DIFF
--- a/domain/blockdag/dag.go
+++ b/domain/blockdag/dag.go
@@ -285,6 +285,17 @@ func (dag *BlockDAG) SelectedTipBlueScore() uint64 {
 	return dag.selectedTip().blueScore
 }
 
+// VirtualBlueHashes returns the blue of the current virtual block
+func (dag *BlockDAG) VirtualBlueHashes() []*daghash.Hash {
+	dag.RLock()
+	defer dag.RUnlock()
+	hashes := make([]*daghash.Hash, len(dag.virtual.blues))
+	for i, blue := range dag.virtual.blues {
+		hashes[i] = blue.hash
+	}
+	return hashes
+}
+
 // VirtualBlueScore returns the blue score of the current virtual block
 func (dag *BlockDAG) VirtualBlueScore() uint64 {
 	return dag.virtual.blueScore

--- a/domain/blockdag/process.go
+++ b/domain/blockdag/process.go
@@ -86,7 +86,7 @@ func (dag *BlockDAG) checkBlockDelay(block *util.Block, flags BehaviorFlags) (is
 	}
 
 	if isDelayed {
-		err := dag.addDelayedBlock(block, delay)
+		err := dag.addDelayedBlock(block, flags, delay)
 		if err != nil {
 			return false, err
 		}
@@ -114,7 +114,7 @@ func (dag *BlockDAG) checkMissingParents(block *util.Block, flags BehaviorFlags)
 	if isParentDelayed {
 		// Add Millisecond to ensure that parent process time will be after its child.
 		delay += time.Millisecond
-		err := dag.addDelayedBlock(block, delay)
+		err := dag.addDelayedBlock(block, flags, delay)
 		if err != nil {
 			return false, false, err
 		}

--- a/domain/blockdag/testdata/dags/dag0.json
+++ b/domain/blockdag/testdata/dags/dag0.json
@@ -1,0 +1,233 @@
+{
+    "K": 4,
+    "GenesisID": "A",
+    "ExpectedReds": [
+        "Q",
+        "H",
+        "I"
+    ],
+    "Blocks": [
+        {
+            "ID": "B",
+            "ExpectedScore": 1,
+            "ExpectedSelectedParent": "A",
+            "ExpectedBlues": [
+                "A"
+            ],
+            "Parents": [
+                "A"
+            ]
+        },
+        {
+            "ID": "C",
+            "ExpectedScore": 2,
+            "ExpectedSelectedParent": "B",
+            "ExpectedBlues": [
+                "B"
+            ],
+            "Parents": [
+                "B"
+            ]
+        },
+        {
+            "ID": "D",
+            "ExpectedScore": 1,
+            "ExpectedSelectedParent": "A",
+            "ExpectedBlues": [
+                "A"
+            ],
+            "Parents": [
+                "A"
+            ]
+        },
+        {
+            "ID": "E",
+            "ExpectedScore": 4,
+            "ExpectedSelectedParent": "C",
+            "ExpectedBlues": [
+                "C",
+                "D"
+            ],
+            "Parents": [
+                "C",
+                "D"
+            ]
+        },
+        {
+            "ID": "F",
+            "ExpectedScore": 1,
+            "ExpectedSelectedParent": "A",
+            "ExpectedBlues": [
+                "A"
+            ],
+            "Parents": [
+                "A"
+            ]
+        },
+        {
+            "ID": "G",
+            "ExpectedScore": 2,
+            "ExpectedSelectedParent": "F",
+            "ExpectedBlues": [
+                "F"
+            ],
+            "Parents": [
+                "F"
+            ]
+        },
+        {
+            "ID": "H",
+            "ExpectedScore": 1,
+            "ExpectedSelectedParent": "A",
+            "ExpectedBlues": [
+                "A"
+            ],
+            "Parents": [
+                "A"
+            ]
+        },
+        {
+            "ID": "I",
+            "ExpectedScore": 1,
+            "ExpectedSelectedParent": "A",
+            "ExpectedBlues": [
+                "A"
+            ],
+            "Parents": [
+                "A"
+            ]
+        },
+        {
+            "ID": "J",
+            "ExpectedScore": 7,
+            "ExpectedSelectedParent": "E",
+            "ExpectedBlues": [
+                "E",
+                "F",
+                "G"
+            ],
+            "Parents": [
+                "E",
+                "G"
+            ]
+        },
+        {
+            "ID": "K",
+            "ExpectedScore": 8,
+            "ExpectedSelectedParent": "J",
+            "ExpectedBlues": [
+                "J"
+            ],
+            "Parents": [
+                "J"
+            ]
+        },
+        {
+            "ID": "L",
+            "ExpectedScore": 9,
+            "ExpectedSelectedParent": "K",
+            "ExpectedBlues": [
+                "K"
+            ],
+            "Parents": [
+                "I",
+                "K"
+            ]
+        },
+        {
+            "ID": "M",
+            "ExpectedScore": 10,
+            "ExpectedSelectedParent": "L",
+            "ExpectedBlues": [
+                "L"
+            ],
+            "Parents": [
+                "L"
+            ]
+        },
+        {
+            "ID": "N",
+            "ExpectedScore": 11,
+            "ExpectedSelectedParent": "M",
+            "ExpectedBlues": [
+                "M"
+            ],
+            "Parents": [
+                "M"
+            ]
+        },
+        {
+            "ID": "O",
+            "ExpectedScore": 11,
+            "ExpectedSelectedParent": "M",
+            "ExpectedBlues": [
+                "M"
+            ],
+            "Parents": [
+                "M"
+            ]
+        },
+        {
+            "ID": "P",
+            "ExpectedScore": 11,
+            "ExpectedSelectedParent": "M",
+            "ExpectedBlues": [
+                "M"
+            ],
+            "Parents": [
+                "M"
+            ]
+        },
+        {
+            "ID": "Q",
+            "ExpectedScore": 11,
+            "ExpectedSelectedParent": "M",
+            "ExpectedBlues": [
+                "M"
+            ],
+            "Parents": [
+                "M"
+            ]
+        },
+        {
+            "ID": "R",
+            "ExpectedScore": 11,
+            "ExpectedSelectedParent": "M",
+            "ExpectedBlues": [
+                "M"
+            ],
+            "Parents": [
+                "M"
+            ]
+        },
+        {
+            "ID": "S",
+            "ExpectedScore": 12,
+            "ExpectedSelectedParent": "R",
+            "ExpectedBlues": [
+                "R"
+            ],
+            "Parents": [
+                "R"
+            ]
+        },
+        {
+            "ID": "T",
+            "ExpectedScore": 16,
+            "ExpectedSelectedParent": "S",
+            "ExpectedBlues": [
+                "S",
+                "P",
+                "N",
+                "O"
+            ],
+            "Parents": [
+                "N",
+                "O",
+                "P",
+                "Q",
+                "S"
+            ]
+        }
+    ]
+}

--- a/domain/blockdag/testdata/dags/dag1.json
+++ b/domain/blockdag/testdata/dags/dag1.json
@@ -1,0 +1,386 @@
+{
+    "K": 4,
+    "GenesisID": "0",
+    "ExpectedReds": [
+        "12",
+        "30",
+        "6",
+        "27",
+        "4",
+        "16",
+        "7",
+        "23",
+        "24",
+        "11",
+        "15",
+        "19",
+        "9"
+    ],
+    "Blocks": [
+        {
+            "ID": "1",
+            "ExpectedScore": 1,
+            "ExpectedSelectedParent": "0",
+            "ExpectedBlues": [
+                "0"
+            ],
+            "Parents": [
+                "0"
+            ]
+        },
+        {
+            "ID": "2",
+            "ExpectedScore": 1,
+            "ExpectedSelectedParent": "0",
+            "ExpectedBlues": [
+                "0"
+            ],
+            "Parents": [
+                "0"
+            ]
+        },
+        {
+            "ID": "3",
+            "ExpectedScore": 1,
+            "ExpectedSelectedParent": "0",
+            "ExpectedBlues": [
+                "0"
+            ],
+            "Parents": [
+                "0"
+            ]
+        },
+        {
+            "ID": "4",
+            "ExpectedScore": 2,
+            "ExpectedSelectedParent": "1",
+            "ExpectedBlues": [
+                "1"
+            ],
+            "Parents": [
+                "1"
+            ]
+        },
+        {
+            "ID": "5",
+            "ExpectedScore": 3,
+            "ExpectedSelectedParent": "2",
+            "ExpectedBlues": [
+                "2",
+                "3"
+            ],
+            "Parents": [
+                "2",
+                "3"
+            ]
+        },
+        {
+            "ID": "6",
+            "ExpectedScore": 2,
+            "ExpectedSelectedParent": "3",
+            "ExpectedBlues": [
+                "3"
+            ],
+            "Parents": [
+                "3"
+            ]
+        },
+        {
+            "ID": "7",
+            "ExpectedScore": 3,
+            "ExpectedSelectedParent": "6",
+            "ExpectedBlues": [
+                "6"
+            ],
+            "Parents": [
+                "6"
+            ]
+        },
+        {
+            "ID": "8",
+            "ExpectedScore": 3,
+            "ExpectedSelectedParent": "2",
+            "ExpectedBlues": [
+                "2",
+                "1"
+            ],
+            "Parents": [
+                "1",
+                "2"
+            ]
+        },
+        {
+            "ID": "9",
+            "ExpectedScore": 5,
+            "ExpectedSelectedParent": "5",
+            "ExpectedBlues": [
+                "5",
+                "6"
+            ],
+            "Parents": [
+                "5",
+                "6"
+            ]
+        },
+        {
+            "ID": "10",
+            "ExpectedScore": 5,
+            "ExpectedSelectedParent": "8",
+            "ExpectedBlues": [
+                "8",
+                "4"
+            ],
+            "Parents": [
+                "8",
+                "4"
+            ]
+        },
+        {
+            "ID": "11",
+            "ExpectedScore": 7,
+            "ExpectedSelectedParent": "9",
+            "ExpectedBlues": [
+                "9",
+                "7"
+            ],
+            "Parents": [
+                "7",
+                "9"
+            ]
+        },
+        {
+            "ID": "12",
+            "ExpectedScore": 8,
+            "ExpectedSelectedParent": "9",
+            "ExpectedBlues": [
+                "9",
+                "8",
+                "10"
+            ],
+            "Parents": [
+                "10",
+                "9"
+            ]
+        },
+        {
+            "ID": "13",
+            "ExpectedScore": 6,
+            "ExpectedSelectedParent": "8",
+            "ExpectedBlues": [
+                "8",
+                "3",
+                "5"
+            ],
+            "Parents": [
+                "5",
+                "8"
+            ]
+        },
+        {
+            "ID": "14",
+            "ExpectedScore": 8,
+            "ExpectedSelectedParent": "13",
+            "ExpectedBlues": [
+                "13",
+                "10"
+            ],
+            "Parents": [
+                "13",
+                "10"
+            ]
+        },
+        {
+            "ID": "15",
+            "ExpectedScore": 9,
+            "ExpectedSelectedParent": "11",
+            "ExpectedBlues": [
+                "11",
+                "13"
+            ],
+            "Parents": [
+                "11",
+                "13"
+            ]
+        },
+        {
+            "ID": "16",
+            "ExpectedScore": 8,
+            "ExpectedSelectedParent": "11",
+            "ExpectedBlues": [
+                "11"
+            ],
+            "Parents": [
+                "11"
+            ]
+        },
+        {
+            "ID": "17",
+            "ExpectedScore": 9,
+            "ExpectedSelectedParent": "14",
+            "ExpectedBlues": [
+                "14"
+            ],
+            "Parents": [
+                "14"
+            ]
+        },
+        {
+            "ID": "18",
+            "ExpectedScore": 7,
+            "ExpectedSelectedParent": "13",
+            "ExpectedBlues": [
+                "13"
+            ],
+            "Parents": [
+                "13"
+            ]
+        },
+        {
+            "ID": "19",
+            "ExpectedScore": 10,
+            "ExpectedSelectedParent": "15",
+            "ExpectedBlues": [
+                "15"
+            ],
+            "Parents": [
+                "18",
+                "15"
+            ]
+        },
+        {
+            "ID": "20",
+            "ExpectedScore": 10,
+            "ExpectedSelectedParent": "17",
+            "ExpectedBlues": [
+                "17"
+            ],
+            "Parents": [
+                "16",
+                "17"
+            ]
+        },
+        {
+            "ID": "21",
+            "ExpectedScore": 12,
+            "ExpectedSelectedParent": "20",
+            "ExpectedBlues": [
+                "20",
+                "18"
+            ],
+            "Parents": [
+                "18",
+                "20"
+            ]
+        },
+        {
+            "ID": "22",
+            "ExpectedScore": 13,
+            "ExpectedSelectedParent": "21",
+            "ExpectedBlues": [
+                "21"
+            ],
+            "Parents": [
+                "19",
+                "21"
+            ]
+        },
+        {
+            "ID": "23",
+            "ExpectedScore": 11,
+            "ExpectedSelectedParent": "17",
+            "ExpectedBlues": [
+                "17",
+                "12"
+            ],
+            "Parents": [
+                "12",
+                "17"
+            ]
+        },
+        {
+            "ID": "24",
+            "ExpectedScore": 13,
+            "ExpectedSelectedParent": "23",
+            "ExpectedBlues": [
+                "23",
+                "20"
+            ],
+            "Parents": [
+                "20",
+                "23"
+            ]
+        },
+        {
+            "ID": "25",
+            "ExpectedScore": 13,
+            "ExpectedSelectedParent": "21",
+            "ExpectedBlues": [
+                "21"
+            ],
+            "Parents": [
+                "21"
+            ]
+        },
+        {
+            "ID": "26",
+            "ExpectedScore": 15,
+            "ExpectedSelectedParent": "22",
+            "ExpectedBlues": [
+                "22",
+                "25"
+            ],
+            "Parents": [
+                "22",
+                "24",
+                "25"
+            ]
+        },
+        {
+            "ID": "27",
+            "ExpectedScore": 9,
+            "ExpectedSelectedParent": "16",
+            "ExpectedBlues": [
+                "16"
+            ],
+            "Parents": [
+                "16"
+            ]
+        },
+        {
+            "ID": "28",
+            "ExpectedScore": 14,
+            "ExpectedSelectedParent": "25",
+            "ExpectedBlues": [
+                "25"
+            ],
+            "Parents": [
+                "23",
+                "25"
+            ]
+        },
+        {
+            "ID": "29",
+            "ExpectedScore": 17,
+            "ExpectedSelectedParent": "26",
+            "ExpectedBlues": [
+                "26",
+                "28"
+            ],
+            "Parents": [
+                "26",
+                "28"
+            ]
+        },
+        {
+            "ID": "30",
+            "ExpectedScore": 10,
+            "ExpectedSelectedParent": "27",
+            "ExpectedBlues": [
+                "27"
+            ],
+            "Parents": [
+                "27"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This will allow me and other researchers to easily create new DAGs (using a tool I wrote in automation) and add them to the test suite with a simple copy-paste

`VirtualBlues()` was added and is a blocker for the DAG creation tool:
https://github.com/kaspanet/automation/blob/c81e5dd2fe0e0ca6c95e81742592bf982b575911/stuff/dagtests/dagtests.go#L239