### PR TITLE
Stop using big.Int to compare hashes

### DIFF
--- a/util/daghash/hash.go
+++ b/util/daghash/hash.go
@@ -224,7 +224,16 @@ func HashToBig(hash *Hash) *big.Int {
 //   +1 if hash >  target
 //
 func (hash *Hash) Cmp(target *Hash) int {
-	return HashToBig(hash).Cmp(HashToBig(target))
+	// We compare the hashes backwards because Hash is stored as a little endian byte array.
+	for i := HashSize - 1; i >= 0; i-- {
+		switch {
+		case hash[i] < target[i]:
+			return -1
+		case hash[i] > target[i]:
+			return 1
+		}
+	}
+	return 0
 }
 
 // Less returns true iff hash a is less than hash b

--- a/util/daghash/hash_test.go
+++ b/util/daghash/hash_test.go
@@ -425,3 +425,13 @@ func TestSort(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkHash_Cmp(b *testing.B) {
+	hash0, err := NewHashFromStr("3333333333333333333333333333333333333333333333333333333333333333")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for n := 0; n < b.N; n++ {
+		hash0.Cmp(hash0)
+	}
+}


### PR DESCRIPTION
`big.Int` stars pretty high in memory profiling of kaspad (usually 2nd/3rd place!) with sometimes over 19% memory usage and I'm sure CPU usage too.
Some mitigations were put in place https://github.com/kaspanet/kaspad/pull/72, but not sure how much they've helped (I don't see a benchmark showing it was better after, only one showing it was bad before)
here I take a different approach and remove `big.Int` from hash.Cmp all together, `big.Int` is still used in the DAA and PoW checks though.

this function is used quite extensively via sorting, examples:
https://github.com/kaspanet/kaspad/blob/8a4ece1101e5382c296f3aeaa9cfbe37c4064e86/domain/blockdag/blockset.go#L93
https://github.com/kaspanet/kaspad/blob/8a4ece1101e5382c296f3aeaa9cfbe37c4064e86/domain/blockdag/blockset.go#L111
https://github.com/kaspanet/kaspad/blob/8a4ece1101e5382c296f3aeaa9cfbe37c4064e86/domain/blockdag/validate.go#L486
https://github.com/kaspanet/kaspad/blob/8a4ece1101e5382c296f3aeaa9cfbe37c4064e86/domain/blockdag/ghostdag.go#L38
and more