### PR TITLE
[NOD-1387] Some small optimizations to block processing

### DIFF
--- a/domain/blockdag/blockset.go
+++ b/domain/blockdag/blockset.go
@@ -36,7 +36,7 @@ func (bs blockSet) remove(node *blockNode) {
 
 // clone clones thie block set
 func (bs blockSet) clone() blockSet {
-	clone := newBlockSet()
+	clone := make(blockSet, len(bs))
 	for node := range bs {
 		clone.add(node)
 	}

--- a/domain/blockdag/dagio.go
+++ b/domain/blockdag/dagio.go
@@ -55,7 +55,14 @@ func serializeOutpoint(w io.Writer, outpoint *appmessage.Outpoint) error {
 		return err
 	}
 
-	return binaryserializer.PutUint32(w, outpointIndexByteOrder, outpoint.Index)
+	var buf [4]byte
+	outpointIndexByteOrder.PutUint32(buf[:], outpoint.Index)
+	_, err = w.Write(buf[:])
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
 }
 
 var outpointSerializeSize = daghash.TxIDSize + 4

--- a/domain/blockdag/utxoio_test.go
+++ b/domain/blockdag/utxoio_test.go
@@ -1,0 +1,36 @@
+package blockdag
+
+import (
+	"bytes"
+	"github.com/kaspanet/kaspad/app/appmessage"
+	"github.com/kaspanet/kaspad/util/daghash"
+	"testing"
+)
+
+func Benchmark_serializeUTXO(b *testing.B) {
+	entry := &UTXOEntry{
+		amount:         5000000000,
+		scriptPubKey:   hexToBytes("76a914ad06dd6ddee55cbca9a9e3713bd7587509a3056488ac"), // p2pkh
+		blockBlueScore: 1432432,
+		packedFlags:    0,
+	}
+	outpoint := &appmessage.Outpoint{
+		TxID: daghash.TxID{
+			0x16, 0x5e, 0x38, 0xe8, 0xb3, 0x91, 0x45, 0x95,
+			0xd9, 0xc6, 0x41, 0xf3, 0xb8, 0xee, 0xc2, 0xf3,
+			0x46, 0x11, 0x89, 0x6b, 0x82, 0x1a, 0x68, 0x3b,
+			0x7a, 0x4e, 0xde, 0xfe, 0x2c, 0x00, 0x00, 0x00,
+		},
+		Index: 0xffffffff,
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 8+1+8+9+len(entry.scriptPubKey)+len(outpoint.TxID)+4))
+
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		err := serializeUTXO(buf, entry, outpoint)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/domain/blockdag/utxoset.go
+++ b/domain/blockdag/utxoset.go
@@ -157,7 +157,7 @@ func (uc utxoCollection) containsWithBlueScore(outpoint appmessage.Outpoint, blu
 
 // clone returns a clone of this collection
 func (uc utxoCollection) clone() utxoCollection {
-	clone := utxoCollection{}
+	clone := make(utxoCollection, len(uc))
 	for outpoint, entry := range uc {
 		clone.add(outpoint, entry)
 	}


### PR DESCRIPTION
these functions were pretty high in benchmarks of a test I'm writing to process thousands of blocks,
[CPU profile before](https://github.com/kaspanet/kaspad/files/5214203/cpu_before.pdf)
[Memory profile before](https://github.com/kaspanet/kaspad/files/5214205/mem_before.pdf)

[CPU profile after the clone changes](https://github.com/kaspanet/kaspad/files/5214210/cpu_clone_preallocate.pdf)
[Memory profile after the clone changes](https://github.com/kaspanet/kaspad/files/5214207/mem_clone_preallocate.pdf)

[CPU profile after this PR](https://github.com/kaspanet/kaspad/files/5214213/cpu_endian_better.pdf)
[Memory profile after this PR](https://github.com/kaspanet/kaspad/files/5214212/mem_endian_better.pdf)

I also wrote a new benchmark for `serializeUTXO` that benchmarks serializing a common UTXO.
before this PR:
```
goos: linux                                                                                                                                                                                                                                  
goarch: amd64                                           
pkg: github.com/kaspanet/kaspad/domain/blockdag
Benchmark_serializeUTXO-16       3623398               325 ns/op         
PASS                                                                                                                  
ok      github.com/kaspanet/kaspad/domain/blockdag      1.522s                                    
```
after:
```
goos: linux
goarch: amd64                                  
pkg: github.com/kaspanet/kaspad/domain/blockdag                                                                       
Benchmark_serializeUTXO-16      15396980                70.6 ns/op
PASS                                                       
ok      github.com/kaspanet/kaspad/domain/blockdag      1.177s
```