### PR TITLE
Add new ErrMissingTxOut  and ErrInvalidTransactionsInNewBlock errors

### DIFF
--- a/domain/consensus/model/externalapi/transaction.go
+++ b/domain/consensus/model/externalapi/transaction.go
@@ -50,6 +50,6 @@ type DomainTransactionOutput struct {
 type DomainTransactionID DomainHash
 
 // String stringifies a transaction ID.
-func (id *DomainTransactionID) String() string {
+func (id DomainTransactionID) String() string {
 	return hex.EncodeToString(id[:])
 }

--- a/domain/consensus/ruleerrors/rule_error.go
+++ b/domain/consensus/ruleerrors/rule_error.go
@@ -276,3 +276,26 @@ func NewErrMissingTxOut(missingOutpoints []externalapi.DomainOutpoint) error {
 		inner:   ErrMissingTxOut{missingOutpoints},
 	})
 }
+
+// ErrInvalidTransactionsInNewBlock indicates that some transactions in a new block are invalid
+type ErrInvalidTransactionsInNewBlock struct {
+	InvalidTransactions []struct {
+		*externalapi.DomainTransaction
+		error
+	}
+}
+
+func (e ErrInvalidTransactionsInNewBlock) Error() string {
+	return fmt.Sprint(e.InvalidTransactions)
+}
+
+// NewErrInvalidTransactionsInNewBlock Creates a new ErrInvalidTransactionsInNewBlock error wrapped in a RuleError
+func NewErrInvalidTransactionsInNewBlock(invalidTransactions []struct {
+	*externalapi.DomainTransaction
+	error
+}) error {
+	return errors.WithStack(RuleError{
+		message: "ErrInvalidTransactionsInNewBlock",
+		inner:   ErrInvalidTransactionsInNewBlock{invalidTransactions},
+	})
+}

--- a/domain/consensus/ruleerrors/rule_error.go
+++ b/domain/consensus/ruleerrors/rule_error.go
@@ -3,6 +3,7 @@ package ruleerrors
 import (
 	"fmt"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"github.com/kaspanet/kaspad/domain/consensus/utils/hashserialization"
 	"github.com/pkg/errors"
 )
 
@@ -277,12 +278,19 @@ func NewErrMissingTxOut(missingOutpoints []externalapi.DomainOutpoint) error {
 	})
 }
 
+// InvalidTransaction is a struct containing an invalid transaction, and the error explaining why it's invalid.
+type InvalidTransaction struct {
+	Transaction *externalapi.DomainTransaction
+	err         error
+}
+
+func (invalid InvalidTransaction) String() string {
+	return fmt.Sprintf("(%v: %s)", hashserialization.TransactionID(invalid.Transaction), invalid.err)
+}
+
 // ErrInvalidTransactionsInNewBlock indicates that some transactions in a new block are invalid
 type ErrInvalidTransactionsInNewBlock struct {
-	InvalidTransactions []struct {
-		*externalapi.DomainTransaction
-		error
-	}
+	InvalidTransactions []InvalidTransaction
 }
 
 func (e ErrInvalidTransactionsInNewBlock) Error() string {
@@ -290,10 +298,7 @@ func (e ErrInvalidTransactionsInNewBlock) Error() string {
 }
 
 // NewErrInvalidTransactionsInNewBlock Creates a new ErrInvalidTransactionsInNewBlock error wrapped in a RuleError
-func NewErrInvalidTransactionsInNewBlock(invalidTransactions []struct {
-	*externalapi.DomainTransaction
-	error
-}) error {
+func NewErrInvalidTransactionsInNewBlock(invalidTransactions []InvalidTransaction) error {
 	return errors.WithStack(RuleError{
 		message: "ErrInvalidTransactionsInNewBlock",
 		inner:   ErrInvalidTransactionsInNewBlock{invalidTransactions},

--- a/domain/consensus/ruleerrors/rule_error_test.go
+++ b/domain/consensus/ruleerrors/rule_error_test.go
@@ -38,12 +38,9 @@ func TestNewErrMissingTxOut(t *testing.T) {
 }
 
 func TestNewErrInvalidTransactionsInNewBlock(t *testing.T) {
-	outer := NewErrInvalidTransactionsInNewBlock([]struct {
-		*externalapi.DomainTransaction
-		error
-	}{{&externalapi.DomainTransaction{Fee: 1337}, ErrNoTxInputs}})
+	outer := NewErrInvalidTransactionsInNewBlock([]InvalidTransaction{{&externalapi.DomainTransaction{Fee: 1337}, ErrNoTxInputs}})
 	//TODO: Implement Stringer for `DomainTransaction`
-	expectedOuterErr := "ErrInvalidTransactionsInNewBlock: [ErrNoTxInputs]"
+	expectedOuterErr := "ErrInvalidTransactionsInNewBlock: [(d328800c7f3ccafe648d3eb43b47eb416f48103f1cd81ddd7a0c41431e4e463a: ErrNoTxInputs)]"
 	inner := &ErrInvalidTransactionsInNewBlock{}
 	if !errors.As(outer, inner) {
 		t.Fatal("TestNewErrInvalidTransactionsInNewBlock: Outer should contain ErrInvalidTransactionsInNewBlock in it")
@@ -52,11 +49,11 @@ func TestNewErrInvalidTransactionsInNewBlock(t *testing.T) {
 	if len(inner.InvalidTransactions) != 1 {
 		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected len(inner.MissingOutpoints) 1, found: %d", len(inner.InvalidTransactions))
 	}
-	if inner.InvalidTransactions[0].error != ErrNoTxInputs {
-		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected ErrNoTxInputs. found: %v", inner.InvalidTransactions[0].error)
+	if inner.InvalidTransactions[0].err != ErrNoTxInputs {
+		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected ErrNoTxInputs. found: %v", inner.InvalidTransactions[0].err)
 	}
-	if inner.InvalidTransactions[0].Fee != 1337 {
-		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected 1337. found: %v", inner.InvalidTransactions[0].Fee)
+	if inner.InvalidTransactions[0].Transaction.Fee != 1337 {
+		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected 1337. found: %v", inner.InvalidTransactions[0].Transaction.Fee)
 	}
 
 	rule := &RuleError{}

--- a/domain/consensus/ruleerrors/rule_error_test.go
+++ b/domain/consensus/ruleerrors/rule_error_test.go
@@ -1,0 +1,38 @@
+package ruleerrors
+
+import (
+	"errors"
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"testing"
+)
+
+func TestNewErrMissingTxOut(t *testing.T) {
+	outer := NewErrMissingTxOut([]externalapi.DomainOutpoint{{TransactionID: externalapi.DomainTransactionID{255, 255, 255}, Index: 5}})
+	expectedOuterErr := "ErrMissingTxOut: [ffffff0000000000000000000000000000000000000000000000000000000000:5]"
+	inner := &ErrMissingTxOut{}
+	if !errors.As(outer, inner) {
+		t.Fatal("TestWrapInRuleError: Outer should contain ErrMissingTxOut in it")
+	}
+
+	if len(inner.MissingOutpoints) != 1 {
+		t.Fatalf("TestWrapInRuleError: Expected len(inner.MissingOutpoints) 1, found: %d", len(inner.MissingOutpoints))
+	}
+	if inner.MissingOutpoints[0].Index != 5 {
+		t.Fatalf("TestWrapInRuleError: Expected 5. found: %d", inner.MissingOutpoints[0].Index)
+	}
+
+	rule := &RuleError{}
+	if !errors.As(outer, rule) {
+		t.Fatal("TestWrapInRuleError: Outer should contain RuleError in it")
+	}
+	if rule.message != "ErrMissingTxOut" {
+		t.Fatalf("TestWrapInRuleError: Expected message = 'ErrMissingTxOut', found: '%s'", rule.message)
+	}
+	if errors.Is(rule.inner, inner) {
+		t.Fatal("TestWrapInRuleError: rule.inner should contain the ErrMissingTxOut in it")
+	}
+
+	if outer.Error() != expectedOuterErr {
+		t.Fatalf("TestWrapInRuleError: Expected %s. found: %s", expectedOuterErr, outer.Error())
+	}
+}

--- a/domain/consensus/ruleerrors/rule_error_test.go
+++ b/domain/consensus/ruleerrors/rule_error_test.go
@@ -36,3 +36,41 @@ func TestNewErrMissingTxOut(t *testing.T) {
 		t.Fatalf("TestWrapInRuleError: Expected %s. found: %s", expectedOuterErr, outer.Error())
 	}
 }
+
+func TestNewErrInvalidTransactionsInNewBlock(t *testing.T) {
+	outer := NewErrInvalidTransactionsInNewBlock([]struct {
+		*externalapi.DomainTransaction
+		error
+	}{{&externalapi.DomainTransaction{Fee: 1337}, ErrNoTxInputs}})
+	//TODO: Implement Stringer for `DomainTransaction`
+	expectedOuterErr := "ErrInvalidTransactionsInNewBlock: [ErrNoTxInputs]"
+	inner := &ErrInvalidTransactionsInNewBlock{}
+	if !errors.As(outer, inner) {
+		t.Fatal("TestNewErrInvalidTransactionsInNewBlock: Outer should contain ErrInvalidTransactionsInNewBlock in it")
+	}
+
+	if len(inner.InvalidTransactions) != 1 {
+		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected len(inner.MissingOutpoints) 1, found: %d", len(inner.InvalidTransactions))
+	}
+	if inner.InvalidTransactions[0].error != ErrNoTxInputs {
+		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected ErrNoTxInputs. found: %v", inner.InvalidTransactions[0].error)
+	}
+	if inner.InvalidTransactions[0].Fee != 1337 {
+		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected 1337. found: %v", inner.InvalidTransactions[0].Fee)
+	}
+
+	rule := &RuleError{}
+	if !errors.As(outer, rule) {
+		t.Fatal("TestNewErrInvalidTransactionsInNewBlock: Outer should contain RuleError in it")
+	}
+	if rule.message != "ErrInvalidTransactionsInNewBlock" {
+		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected message = 'ErrInvalidTransactionsInNewBlock', found: '%s'", rule.message)
+	}
+	if errors.Is(rule.inner, inner) {
+		t.Fatal("TestNewErrInvalidTransactionsInNewBlock: rule.inner should contain the ErrInvalidTransactionsInNewBlock in it")
+	}
+
+	if outer.Error() != expectedOuterErr {
+		t.Fatalf("TestNewErrInvalidTransactionsInNewBlock: Expected %s. found: %s", expectedOuterErr, outer.Error())
+	}
+}

--- a/domain/consensus/utils/hashserialization/transaction.go
+++ b/domain/consensus/utils/hashserialization/transaction.go
@@ -130,7 +130,7 @@ func serializeTransaction(w io.Writer, tx *externalapi.DomainTransaction, encodi
 		return err
 	}
 
-	err = WriteElement(w, tx.PayloadHash)
+	err = WriteElement(w, &tx.PayloadHash)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Should I leave the UTXOEntries checks scattered across consensus or should we have a sanity check and later assume it is not nil?