### PR TITLE
Fix double printing the mainnet has not launched yet message

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -46,7 +46,7 @@ func StartApp() error {
 	// initializes logging and configures it accordingly.
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		return err
 	}
 	defer panics.HandlePanic(log, "MAIN", nil)

--- a/infrastructure/config/network.go
+++ b/infrastructure/config/network.go
@@ -48,10 +48,7 @@ func (networkFlags *NetworkFlags) ResolveNetwork(parser *flags.Parser) error {
 	}
 
 	if numNets == 0 {
-		message := "Mainnet has not launched yet, use --testnet to run in testnet mode"
-		err := errors.Errorf(message)
-		fmt.Fprintln(os.Stderr, err)
-		return err
+		return errors.Errorf("Mainnet has not launched yet, use --testnet to run in testnet mode")
 	}
 
 	return nil


### PR DESCRIPTION
Before:
```
Mainnet has not launched yet, use --testnet to run in testnet mode                                                    
Mainnet has not launched yet, use --testnet to run in testnet modeexit status 1                                       
```

After:
```
Mainnet has not launched yet, use --testnet to run in testnet mode
exit status 1
```