### PR TITLE
Stop returning teardown from NewTestConsensus

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # -- multistage docker build: stage #1: build stage
-FROM golang:1.14-alpine AS build
+FROM golang:1.15-alpine AS build
 
 RUN mkdir -p /go/src/github.com/kaspanet/kaspad
 

--- a/domain/consensus/finality_test.go
+++ b/domain/consensus/finality_test.go
@@ -15,11 +15,7 @@ func TestFinality(t *testing.T) {
 		params.FinalityDuration = 50 * params.TargetTimePerBlock
 
 		factory := NewFactory()
-		consensus, teardown, err := factory.NewTestConsensus(params, "TestFinality")
-		if err != nil {
-			t.Fatalf("Error setting up consensus: %+v", err)
-		}
-		defer teardown()
+		consensus := factory.NewTestConsensus(t, params)
 
 		buildAndInsertBlock := func(parentHashes []*externalapi.DomainHash) (*externalapi.DomainBlock, error) {
 			block, err := consensus.BuildBlockWithParents(parentHashes, nil, nil)
@@ -39,6 +35,7 @@ func TestFinality(t *testing.T) {
 		var mainChainTip *externalapi.DomainBlock
 		mainChainTipHash := params.GenesisHash
 
+		var err error
 		for i := uint64(0); i < finalityInterval-1; i++ {
 			mainChainTip, err = buildAndInsertBlock([]*externalapi.DomainHash{mainChainTipHash})
 			if err != nil {
@@ -60,7 +57,7 @@ func TestFinality(t *testing.T) {
 		var sideChainTip *externalapi.DomainBlock
 		sideChainTipHash := params.GenesisHash
 		for i := uint64(0); i < finalityInterval-2; i++ {
-			sideChainTip, err = buildAndInsertBlock([]*externalapi.DomainHash{sideChainTipHash})
+			sideChainTip, err := buildAndInsertBlock([]*externalapi.DomainHash{sideChainTipHash})
 			if err != nil {
 				t.Fatalf("TestFinality: Failed to process sidechain Block #%d: %v", i, err)
 			}
@@ -80,7 +77,7 @@ func TestFinality(t *testing.T) {
 
 		// Add two more blocks in the side-chain until it becomes the selected chain
 		for i := uint64(0); i < 2; i++ {
-			sideChainTip, err = buildAndInsertBlock([]*externalapi.DomainHash{sideChainTipHash})
+			sideChainTip, err := buildAndInsertBlock([]*externalapi.DomainHash{sideChainTipHash})
 			if err != nil {
 				t.Fatalf("TestFinality: Failed to process sidechain Block #%d: %v", i, err)
 			}

--- a/domain/consensus/processes/consensusstatemanager/calculate_past_utxo_test.go
+++ b/domain/consensus/processes/consensusstatemanager/calculate_past_utxo_test.go
@@ -19,11 +19,7 @@ func TestUTXOCommitment(t *testing.T) {
 		params.BlockCoinbaseMaturity = 0
 		factory := consensus.NewFactory()
 
-		consensus, teardown, err := factory.NewTestConsensus(params, "TestUTXOCommitment")
-		if err != nil {
-			t.Fatalf("Error setting up consensus: %+v", err)
-		}
-		defer teardown()
+		consensus := factory.NewTestConsensus(t, params)
 
 		// Build the following DAG:
 		// G <- A <- B <- C <- E
@@ -115,14 +111,11 @@ func TestPastUTXOMultiset(t *testing.T) {
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		factory := consensus.NewFactory()
 
-		consensus, teardown, err := factory.NewTestConsensus(params, "TestUTXOCommitment")
-		if err != nil {
-			t.Fatalf("Error setting up consensus: %+v", err)
-		}
-		defer teardown()
+		consensus := factory.NewTestConsensus(t, params)
 
 		// Build a short chain
 		currentHash := params.GenesisHash
+		var err error
 		for i := 0; i < 3; i++ {
 			currentHash, err = consensus.AddBlock([]*externalapi.DomainHash{currentHash}, nil, nil)
 			if err != nil {

--- a/domain/consensus/processes/consensusstatemanager/resolve_block_status_test.go
+++ b/domain/consensus/processes/consensusstatemanager/resolve_block_status_test.go
@@ -19,11 +19,7 @@ func TestDoubleSpends(t *testing.T) {
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		factory := consensus.NewFactory()
 
-		consensus, teardown, err := factory.NewTestConsensus(params, "TestUTXOCommitment")
-		if err != nil {
-			t.Fatalf("Error setting up consensus: %+v", err)
-		}
-		defer teardown()
+		consensus := factory.NewTestConsensus(t, params)
 
 		// Mine chain of two blocks to fund our double spend
 		firstBlockHash, err := consensus.AddBlock([]*externalapi.DomainHash{params.GenesisHash}, nil, nil)

--- a/domain/consensus/processes/dagtopologymanager/dagtopologymanager_external_test.go
+++ b/domain/consensus/processes/dagtopologymanager/dagtopologymanager_external_test.go
@@ -12,11 +12,7 @@ import (
 func TestIsAncestorOf(t *testing.T) {
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		factory := consensus.NewFactory()
-		tc, tearDown, err := factory.NewTestConsensus(params, "TestIsAncestorOf")
-		if err != nil {
-			t.Fatalf("NewTestConsensus: %s", err)
-		}
-		defer tearDown()
+		tc := factory.NewTestConsensus(t, params)
 
 		// Add a chain of two blocks above the genesis. This will be the
 		// selected parent chain.

--- a/domain/consensus/processes/dagtraversalmanager/window_test.go
+++ b/domain/consensus/processes/dagtraversalmanager/window_test.go
@@ -309,11 +309,7 @@ func TestBlueBlockWindow(t *testing.T) {
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		params.K = 1
 		factory := consensus.NewFactory()
-		tc, tearDown, err := factory.NewTestConsensus(params, "TestBlueBlockWindow")
-		if err != nil {
-			t.Fatalf("NewTestConsensus: %s", err)
-		}
-		defer tearDown()
+		tc := factory.NewTestConsensus(t, params)
 
 		windowSize := uint64(10)
 		blockByIDMap := make(map[string]*externalapi.DomainHash)

--- a/domain/consensus/processes/pastmediantimemanager/pastmediantimemanager_test.go
+++ b/domain/consensus/processes/pastmediantimemanager/pastmediantimemanager_test.go
@@ -12,11 +12,7 @@ import (
 func TestPastMedianTime(t *testing.T) {
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		factory := consensus.NewFactory()
-		tc, tearDown, err := factory.NewTestConsensus(params, "TestUpdateReindexRoot")
-		if err != nil {
-			t.Fatalf("NewTestConsensus: %s", err)
-		}
-		defer tearDown()
+		tc := factory.NewTestConsensus(t, params)
 
 		numBlocks := uint32(300)
 		blockHashes := make([]*externalapi.DomainHash, numBlocks)

--- a/domain/consensus/processes/reachabilitymanager/reachability_external_test.go
+++ b/domain/consensus/processes/reachabilitymanager/reachability_external_test.go
@@ -12,11 +12,7 @@ func TestAddChildThatPointsDirectlyToTheSelectedParentChainBelowReindexRoot(t *t
 	reachabilityReindexWindow := uint64(10)
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		factory := consensus.NewFactory()
-		tc, tearDown, err := factory.NewTestConsensus(params, "TestAddChildThatPointsDirectlyToTheSelectedParentChainBelowReindexRoot")
-		if err != nil {
-			t.Fatalf("NewTestConsensus: %+v", err)
-		}
-		defer tearDown()
+		tc := factory.NewTestConsensus(t, params)
 
 		tc.ReachabilityManager().SetReachabilityReindexWindow(reachabilityReindexWindow)
 
@@ -67,11 +63,7 @@ func TestUpdateReindexRoot(t *testing.T) {
 	reachabilityReindexWindow := uint64(10)
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		factory := consensus.NewFactory()
-		tc, tearDown, err := factory.NewTestConsensus(params, "TestUpdateReindexRoot")
-		if err != nil {
-			t.Fatalf("NewTestConsensus: %s", err)
-		}
-		defer tearDown()
+		tc := factory.NewTestConsensus(t, params)
 
 		tc.ReachabilityManager().SetReachabilityReindexWindow(reachabilityReindexWindow)
 
@@ -157,11 +149,7 @@ func TestReindexIntervalsEarlierThanReindexRoot(t *testing.T) {
 	reachabilityReindexWindow := uint64(10)
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		factory := consensus.NewFactory()
-		tc, tearDown, err := factory.NewTestConsensus(params, "TestUpdateReindexRoot")
-		if err != nil {
-			t.Fatalf("NewTestConsensus: %s", err)
-		}
-		defer tearDown()
+		tc := factory.NewTestConsensus(t, params)
 
 		tc.ReachabilityManager().SetReachabilityReindexWindow(reachabilityReindexWindow)
 
@@ -291,16 +279,13 @@ func TestTipsAfterReindexIntervalsEarlierThanReindexRoot(t *testing.T) {
 	reachabilityReindexWindow := uint64(10)
 	testutils.ForAllNets(t, true, func(t *testing.T, params *dagconfig.Params) {
 		factory := consensus.NewFactory()
-		tc, tearDown, err := factory.NewTestConsensus(params, "TestUpdateReindexRoot")
-		if err != nil {
-			t.Fatalf("NewTestConsensus: %s", err)
-		}
-		defer tearDown()
+		tc := factory.NewTestConsensus(t, params)
 
 		tc.ReachabilityManager().SetReachabilityReindexWindow(reachabilityReindexWindow)
 
 		// Add a chain of reachabilityReindexWindow + 1 blocks above the genesis.
 		// This will set the reindex root to the child of genesis
+		var err error
 		chainTipHash := params.GenesisHash
 		for i := uint64(0); i < reachabilityReindexWindow+1; i++ {
 			chainTipHash, err = tc.AddBlock([]*externalapi.DomainHash{chainTipHash}, nil, nil)

--- a/util/bech32/internal_test.go
+++ b/util/bech32/internal_test.go
@@ -21,10 +21,10 @@ func TestBech32(t *testing.T) {
 		{"::qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq40ku0e3z", true},
 		{"split:checkupstagehandshakeupstreamerranterredcaperred3za27wc5", true},
 		{"aaa:bbb", false}, // too short
-		{"split:checkupstagehandshakeupstreamerranterredCaperred3za27wc5", false},                   // mixed uppercase and lowercase
-		{"split:checkupstagehandshakeupstreamerranterredcaperred3za28wc5", false},                   // invalid checksum
-		{"s lit:checkupstagehandshakeupstreamerranterredcaperred3za27wc5", false},                   // invalid character (space) in prefix
-		{"spl" + string(127) + "t:checkupstagehandshakeupstreamerranterredcaperred3za27wc5", false}, // invalid character (DEL) in prefix
+		{"split:checkupstagehandshakeupstreamerranterredCaperred3za27wc5", false},                         // mixed uppercase and lowercase
+		{"split:checkupstagehandshakeupstreamerranterredcaperred3za28wc5", false},                         // invalid checksum
+		{"s lit:checkupstagehandshakeupstreamerranterredcaperred3za27wc5", false},                         // invalid character (space) in prefix
+		{"spl" + string(rune(127)) + "t:checkupstagehandshakeupstreamerranterredcaperred3za27wc5", false}, // invalid character (DEL) in prefix
 		{"split:cheosgds2s3c", false}, // invalid character (o) in data part
 		{"split:te5peu7", false},      // too short data part
 		{":checkupstagehandshakeupstreamerranterredcaperred3za27wc5", false},                                   // empty prefix
@@ -40,7 +40,7 @@ func TestBech32(t *testing.T) {
 		if !test.valid {
 			// Invalid string decoding should result in error.
 			if err == nil {
-				t.Error("expected decoding to fail for "+
+				t.Errorf("expected decoding to fail for "+
 					"invalid string %v", test.str)
 			}
 			continue


### PR DESCRIPTION
This uses the `testing.TB` interface to support both tests and benchmarks https://golang.org/pkg/testing/#TB

and uses the new `T.TempDir()` that was added in Go 1.15 (hence the docker bump).
also use the `T.Cleanup(func(){})` to run the teardown instead of manually doing that in every function