### PR TITLE
Replace BlueWindow implementation to accomadate a better DAA scheme

### DIFF
--- a/domain/consensus/model/interface_processes_dagtraversalmanager.go
+++ b/domain/consensus/model/interface_processes_dagtraversalmanager.go
@@ -10,7 +10,7 @@ type DAGTraversalManager interface {
 	SelectedParentIterator(highHash *externalapi.DomainHash) BlockIterator
 	SelectedChildIterator(highHash, lowHash *externalapi.DomainHash) (BlockIterator, error)
 	AnticoneFromContext(context, lowHash *externalapi.DomainHash) ([]*externalapi.DomainHash, error)
-	BlueWindow(highHash *externalapi.DomainHash, windowSize uint64) ([]*externalapi.DomainHash, error)
+	BlueWindow(highHash *externalapi.DomainHash, windowSize int) ([]*externalapi.DomainHash, error)
 	NewDownHeap() BlockHeap
 	NewUpHeap() BlockHeap
 }

--- a/domain/consensus/processes/dagtraversalmanager/block_heap.go
+++ b/domain/consensus/processes/dagtraversalmanager/block_heap.go
@@ -16,7 +16,7 @@ func (left *blockHeapNode) less(right *blockHeapNode, gm model.GHOSTDAGManager) 
 	return gm.Less(left.hash, left.ghostdagData, right.hash, right.ghostdagData)
 }
 
-// baseHeap  is an implementation for heap.Interface that sorts blocks by their height
+// baseHeap  is an implementation for heap.Interface that sorts blocks by their blueWork+hash
 type baseHeap struct {
 	slice           []*blockHeapNode
 	ghostdagManager model.GHOSTDAGManager
@@ -37,7 +37,7 @@ func (h *baseHeap) Pop() interface{} {
 	return popped
 }
 
-// peek returns the block with lowest height from this heap without removing it
+// peek returns the block with lowest blueWork+hash from this heap without removing it
 func (h *baseHeap) peek() *blockHeapNode {
 	return h.slice[0]
 }
@@ -60,7 +60,7 @@ func (h downHeap) Less(i, j int) bool {
 	return !heapNodeI.less(heapNodeJ, h.ghostdagManager)
 }
 
-// blockHeap represents a mutable heap of Blocks, sorted by their height
+// blockHeap represents a mutable heap of blocks, sorted by their blueWork+hash
 type blockHeap struct {
 	impl          heap.Interface
 	ghostdagStore model.GHOSTDAGDataStore
@@ -89,7 +89,7 @@ func (dtm dagTraversalManager) NewUpHeap() model.BlockHeap {
 	return h
 }
 
-// Pop removes the block with lowest height from this heap and returns it
+// Pop removes the block with lowest blueWork+hash from this heap and returns it
 func (bh blockHeap) Pop() *externalapi.DomainHash {
 	return heap.Pop(bh.impl).(*blockHeapNode).hash
 }
@@ -114,7 +114,7 @@ func (bh blockHeap) Len() int {
 	return bh.impl.Len()
 }
 
-// sizedUpBlockHeap represents a mutable heap of Blocks, sorted by their height, capped by a specific size.
+// sizedUpBlockHeap represents a mutable heap of Blocks, sorted by their blueWork+hash, capped by a specific size.
 type sizedUpBlockHeap struct {
 	impl          upHeap
 	ghostdagStore model.GHOSTDAGDataStore
@@ -137,12 +137,12 @@ func (sbh *sizedUpBlockHeap) len() int {
 	return sbh.impl.Len()
 }
 
-// pop removes the block with lowest height from this heap and returns it
+// pop removes the block with lowest blueWork+hash from this heap and returns it
 func (sbh *sizedUpBlockHeap) pop() *externalapi.DomainHash {
 	return heap.Pop(&sbh.impl).(*blockHeapNode).hash
 }
 
-// tryPush tries to pushe the block onto the heap, if the heap is full and it's less than the minimum it rejects it
+// tryPush tries to push the block onto the heap, if the heap is full and it's less than the minimum it rejects it
 func (sbh *sizedUpBlockHeap) tryPush(blockHash *externalapi.DomainHash) (bool, error) {
 	ghostdagData, err := sbh.ghostdagStore.Get(sbh.dbContext, blockHash)
 	if err != nil {

--- a/domain/consensus/processes/dagtraversalmanager/window.go
+++ b/domain/consensus/processes/dagtraversalmanager/window.go
@@ -6,7 +6,7 @@ import "github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 // blues in the past of startindNode, sorted by GHOSTDAG order.
 // If the number of blues in the past of startingNode is less then windowSize,
 // the window will be padded by genesis blocks to achieve a size of windowSize.
-func (dtm *dagTraversalManager) BlueWindow(startingBlock *externalapi.DomainHash, windowSize uint64) ([]*externalapi.DomainHash, error) {
+func (dtm *dagTraversalManager) BlueWindow(startingBlock *externalapi.DomainHash, windowSize int) ([]*externalapi.DomainHash, error) {
 	window := make([]*externalapi.DomainHash, 0, windowSize)
 
 	currentHash := startingBlock
@@ -15,10 +15,10 @@ func (dtm *dagTraversalManager) BlueWindow(startingBlock *externalapi.DomainHash
 		return nil, err
 	}
 
-	for uint64(len(window)) < windowSize && currentGHOSTDAGData.SelectedParent() != nil {
+	for len(window) < windowSize && currentGHOSTDAGData.SelectedParent() != nil {
 		for _, blue := range currentGHOSTDAGData.MergeSetBlues() {
 			window = append(window, blue)
-			if uint64(len(window)) == windowSize {
+			if len(window) == windowSize {
 				break
 			}
 		}
@@ -30,9 +30,9 @@ func (dtm *dagTraversalManager) BlueWindow(startingBlock *externalapi.DomainHash
 		}
 	}
 
-	if uint64(len(window)) < windowSize {
+	if len(window) < windowSize {
 		genesis := currentHash
-		for uint64(len(window)) < windowSize {
+		for len(window) < windowSize {
 			window = append(window, genesis)
 		}
 	}

--- a/domain/consensus/processes/dagtraversalmanager/window.go
+++ b/domain/consensus/processes/dagtraversalmanager/window.go
@@ -45,8 +45,9 @@ func (dtm *dagTraversalManager) BlueWindow(startingBlock *externalapi.DomainHash
 				break
 			}
 		}
-		for i := len(currentGHOSTDAGData.MergeSetReds()) - 1; i >= 0; i-- {
-			added, err := windowHeap.tryPush(currentGHOSTDAGData.MergeSetReds()[i])
+		mergeSetReds := currentGHOSTDAGData.MergeSetReds()
+		for i := len(mergeSetReds) - 1; i >= 0; i-- {
+			added, err := windowHeap.tryPush(mergeSetReds[i])
 			if err != nil {
 				return nil, err
 			}

--- a/domain/consensus/processes/dagtraversalmanager/window.go
+++ b/domain/consensus/processes/dagtraversalmanager/window.go
@@ -1,33 +1,75 @@
 package dagtraversalmanager
 
-import "github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+import (
+	"sort"
+
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+)
 
 // blueBlockWindow returns a blockWindow of the given size that contains the
 // blues in the past of startindNode, sorted by GHOSTDAG order.
 // If the number of blues in the past of startingNode is less then windowSize,
 // the window will be padded by genesis blocks to achieve a size of windowSize.
 func (dtm *dagTraversalManager) BlueWindow(startingBlock *externalapi.DomainHash, windowSize int) ([]*externalapi.DomainHash, error) {
-	window := make([]*externalapi.DomainHash, 0, windowSize)
-
 	currentHash := startingBlock
 	currentGHOSTDAGData, err := dtm.ghostdagDataStore.Get(dtm.databaseContext, currentHash)
 	if err != nil {
 		return nil, err
 	}
 
-	for len(window) < windowSize && currentGHOSTDAGData.SelectedParent() != nil {
-		for _, blue := range currentGHOSTDAGData.MergeSetBlues() {
-			window = append(window, blue)
-			if len(window) == windowSize {
+	windowHeap := dtm.newSizedUpHeap(windowSize)
+
+	for windowHeap.len() <= windowSize && currentGHOSTDAGData.SelectedParent() != nil {
+		added, err := windowHeap.tryPush(currentGHOSTDAGData.SelectedParent())
+		if err != nil {
+			return nil, err
+		}
+
+		// If the window is full and the selected parent is less than the minimum then we break
+		// because this means that there cannot be any more blocks in the past with higher blueWork
+		if !added {
+			break
+		}
+
+		// Now we go over the merge set.
+		// Remove the SP from the blue merge set because we already added it.
+		mergeSetBlues := currentGHOSTDAGData.MergeSetBlues()[1:]
+		// Go over the merge set in reverse because it's ordered in reverse by blueWork.
+		for i := len(mergeSetBlues) - 1; i >= 0; i-- {
+			added, err := windowHeap.tryPush(mergeSetBlues[i])
+			if err != nil {
+				return nil, err
+			}
+			// If it's smaller than minimum then we won't be able to add the rest because they're even smaller.
+			if !added {
 				break
 			}
 		}
-
+		for i := len(currentGHOSTDAGData.MergeSetReds()) - 1; i >= 0; i-- {
+			added, err := windowHeap.tryPush(currentGHOSTDAGData.MergeSetReds()[i])
+			if err != nil {
+				return nil, err
+			}
+			// If it's smaller than minimum then we won't be able to add the rest because they're even smaller.
+			if !added {
+				break
+			}
+		}
 		currentHash = currentGHOSTDAGData.SelectedParent()
 		currentGHOSTDAGData, err = dtm.ghostdagDataStore.Get(dtm.databaseContext, currentHash)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// a heap is not a sorted list, and the interface promises to be sorted so we now need to sort this
+	sort.Slice(windowHeap.impl.slice, func(i, j int) bool {
+		return windowHeap.impl.slice[j].less(windowHeap.impl.slice[i], dtm.ghostdagManager)
+	})
+
+	window := make([]*externalapi.DomainHash, 0, windowSize)
+	for _, b := range windowHeap.impl.slice {
+		window = append(window, b.hash)
 	}
 
 	if len(window) < windowSize {

--- a/domain/consensus/processes/dagtraversalmanager/window_test.go
+++ b/domain/consensus/processes/dagtraversalmanager/window_test.go
@@ -315,7 +315,7 @@ func TestBlueBlockWindow(t *testing.T) {
 		}
 		defer tearDown()
 
-		windowSize := uint64(10)
+		windowSize := 10
 		blockByIDMap := make(map[string]*externalapi.DomainHash)
 		idByBlockMap := make(map[externalapi.DomainHash]string)
 		blockByIDMap["A"] = params.GenesisHash

--- a/domain/consensus/processes/dagtraversalmanager/window_test.go
+++ b/domain/consensus/processes/dagtraversalmanager/window_test.go
@@ -56,37 +56,37 @@ func TestBlueBlockWindow(t *testing.T) {
 			{
 				parents:                          []string{"H", "F"},
 				id:                               "I",
-				expectedWindowWithGenesisPadding: []string{"F", "D", "C", "B", "A", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"F", "D", "H", "C", "B", "G", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"I"},
 				id:                               "J",
-				expectedWindowWithGenesisPadding: []string{"I", "F", "D", "C", "B", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"I", "F", "D", "H", "C", "B", "G", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"J"},
 				id:                               "K",
-				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "D", "C", "B", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "D", "H", "C", "B", "G", "A", "A"},
 			},
 			{
 				parents:                          []string{"K"},
 				id:                               "L",
-				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "D", "C", "B", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "D", "H", "C", "B", "G", "A"},
 			},
 			{
 				parents:                          []string{"L"},
 				id:                               "M",
-				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "D", "C", "B", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "D", "H", "C", "B", "G"},
 			},
 			{
 				parents:                          []string{"M"},
 				id:                               "N",
-				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "D", "C", "B", "A"},
+				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "D", "H", "C", "B"},
 			},
 			{
 				parents:                          []string{"N"},
 				id:                               "O",
-				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "D", "C", "B"},
+				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "D", "H", "C"},
 			},
 		},
 		"kaspa-testnet": {
@@ -128,37 +128,37 @@ func TestBlueBlockWindow(t *testing.T) {
 			{
 				parents:                          []string{"H", "F"},
 				id:                               "I",
-				expectedWindowWithGenesisPadding: []string{"F", "C", "D", "B", "A", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"F", "C", "H", "D", "B", "G", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"I"},
 				id:                               "J",
-				expectedWindowWithGenesisPadding: []string{"I", "F", "C", "D", "B", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"I", "F", "C", "H", "D", "B", "G", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"J"},
 				id:                               "K",
-				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "C", "D", "B", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "C", "H", "D", "B", "G", "A", "A"},
 			},
 			{
 				parents:                          []string{"K"},
 				id:                               "L",
-				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "C", "D", "B", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "C", "H", "D", "B", "G", "A"},
 			},
 			{
 				parents:                          []string{"L"},
 				id:                               "M",
-				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "C", "D", "B", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "C", "H", "D", "B", "G"},
 			},
 			{
 				parents:                          []string{"M"},
 				id:                               "N",
-				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "C", "D", "B", "A"},
+				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "C", "H", "D", "B"},
 			},
 			{
 				parents:                          []string{"N"},
 				id:                               "O",
-				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "C", "D", "B"},
+				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "C", "H", "D"},
 			},
 		},
 		"kaspa-devnet": {
@@ -200,37 +200,37 @@ func TestBlueBlockWindow(t *testing.T) {
 			{
 				parents:                          []string{"H", "F"},
 				id:                               "I",
-				expectedWindowWithGenesisPadding: []string{"F", "C", "D", "B", "A", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"F", "C", "H", "D", "B", "G", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"I"},
 				id:                               "J",
-				expectedWindowWithGenesisPadding: []string{"I", "F", "C", "D", "B", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"I", "F", "C", "H", "D", "B", "G", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"J"},
 				id:                               "K",
-				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "C", "D", "B", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "C", "H", "D", "B", "G", "A", "A"},
 			},
 			{
 				parents:                          []string{"K"},
 				id:                               "L",
-				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "C", "D", "B", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "C", "H", "D", "B", "G", "A"},
 			},
 			{
 				parents:                          []string{"L"},
 				id:                               "M",
-				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "C", "D", "B", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "C", "H", "D", "B", "G"},
 			},
 			{
 				parents:                          []string{"M"},
 				id:                               "N",
-				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "C", "D", "B", "A"},
+				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "C", "H", "D", "B"},
 			},
 			{
 				parents:                          []string{"N"},
 				id:                               "O",
-				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "C", "D", "B"},
+				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "C", "H", "D"},
 			},
 		},
 		"kaspa-simnet": {
@@ -272,37 +272,37 @@ func TestBlueBlockWindow(t *testing.T) {
 			{
 				parents:                          []string{"H", "F"},
 				id:                               "I",
-				expectedWindowWithGenesisPadding: []string{"F", "D", "C", "B", "A", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"F", "D", "C", "H", "B", "G", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"I"},
 				id:                               "J",
-				expectedWindowWithGenesisPadding: []string{"I", "F", "D", "C", "B", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"I", "F", "D", "C", "H", "B", "G", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"J"},
 				id:                               "K",
-				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "D", "C", "B", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "D", "C", "H", "B", "G", "A", "A"},
 			},
 			{
 				parents:                          []string{"K"},
 				id:                               "L",
-				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "D", "C", "B", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "D", "C", "H", "B", "G", "A"},
 			},
 			{
 				parents:                          []string{"L"},
 				id:                               "M",
-				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "D", "C", "B", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "D", "C", "H", "B", "G"},
 			},
 			{
 				parents:                          []string{"M"},
 				id:                               "N",
-				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "D", "C", "B", "A"},
+				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "D", "C", "H", "B"},
 			},
 			{
 				parents:                          []string{"N"},
 				id:                               "O",
-				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "D", "C", "B"},
+				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "D", "C", "H"},
 			},
 		},
 	}

--- a/domain/consensus/processes/difficultymanager/blockwindow.go
+++ b/domain/consensus/processes/difficultymanager/blockwindow.go
@@ -32,7 +32,7 @@ func (dm *difficultyManager) getDifficultyBlock(blockHash *externalapi.DomainHas
 // blues in the past of startindNode, sorted by GHOSTDAG order.
 // If the number of blues in the past of startingNode is less then windowSize,
 // the window will be padded by genesis blocks to achieve a size of windowSize.
-func (dm *difficultyManager) blueBlockWindow(startingNode *externalapi.DomainHash, windowSize uint64) (blockWindow, error) {
+func (dm *difficultyManager) blueBlockWindow(startingNode *externalapi.DomainHash, windowSize int) (blockWindow, error) {
 	window := make(blockWindow, 0, windowSize)
 	windowHashes, err := dm.dagTraversalManager.BlueWindow(startingNode, windowSize)
 	if err != nil {

--- a/domain/consensus/processes/difficultymanager/difficultymanager.go
+++ b/domain/consensus/processes/difficultymanager/difficultymanager.go
@@ -21,7 +21,7 @@ type difficultyManager struct {
 	dagTraversalManager            model.DAGTraversalManager
 	genesisHash                    *externalapi.DomainHash
 	powMax                         *big.Int
-	difficultyAdjustmentWindowSize uint64
+	difficultyAdjustmentWindowSize int
 	disableDifficultyAdjustment    bool
 	targetTimePerBlock             time.Duration
 }
@@ -34,7 +34,7 @@ func New(databaseContext model.DBReader,
 	dagTopologyManager model.DAGTopologyManager,
 	dagTraversalManager model.DAGTraversalManager,
 	powMax *big.Int,
-	difficultyAdjustmentWindowSize uint64,
+	difficultyAdjustmentWindowSize int,
 	disableDifficultyAdjustment bool,
 	targetTimePerBlock time.Duration,
 	genesisHash *externalapi.DomainHash) model.DifficultyManager {
@@ -95,7 +95,7 @@ func (dm *difficultyManager) RequiredDifficulty(blockHash *externalapi.DomainHas
 	}
 
 	// Not enough blocks for building a difficulty window.
-	if bluestGhostDAG.BlueScore() < dm.difficultyAdjustmentWindowSize+1 {
+	if bluestGhostDAG.BlueScore() < uint64(dm.difficultyAdjustmentWindowSize)+1 {
 		return dm.genesisBits()
 	}
 

--- a/domain/consensus/processes/difficultymanager/difficultymanager_test.go
+++ b/domain/consensus/processes/difficultymanager/difficultymanager_test.go
@@ -86,14 +86,14 @@ func TestDifficulty(t *testing.T) {
 
 		tipHash := params.GenesisHash
 		tip := params.GenesisBlock
-		for i := uint64(0); i < params.DifficultyAdjustmentWindowSize; i++ {
+		for i := 0; i < params.DifficultyAdjustmentWindowSize; i++ {
 			tip, tipHash = addBlock(0, tipHash)
 			if tip.Header.Bits != params.GenesisBlock.Header.Bits {
 				t.Fatalf("As long as the bluest parent's blue score is less then the difficulty adjustment " +
 					"window size, the difficulty should be the same as genesis'")
 			}
 		}
-		for i := uint64(0); i < params.DifficultyAdjustmentWindowSize+100; i++ {
+		for i := 0; i < params.DifficultyAdjustmentWindowSize+100; i++ {
 			tip, tipHash = addBlock(0, tipHash)
 			if tip.Header.Bits != params.GenesisBlock.Header.Bits {
 				t.Fatalf("As long as the block rate remains the same, the difficulty shouldn't change")
@@ -130,7 +130,7 @@ func TestDifficulty(t *testing.T) {
 		}
 
 		// Increase block rate to increase difficulty
-		for i := uint64(0); i < params.DifficultyAdjustmentWindowSize; i++ {
+		for i := 0; i < params.DifficultyAdjustmentWindowSize; i++ {
 			tip, tipHash = addBlockWithMinimumTime(tipHash)
 			tipGHOSTDAGData, err := tc.GHOSTDAGDataStore().Get(tc.DatabaseContext(), tipHash)
 			if err != nil {
@@ -150,7 +150,7 @@ func TestDifficulty(t *testing.T) {
 
 		// Add blocks until difficulty stabilizes
 		lastBits := tip.Header.Bits
-		sameBitsCount := uint64(0)
+		sameBitsCount := 0
 		for sameBitsCount < params.DifficultyAdjustmentWindowSize+1 {
 			tip, tipHash = addBlock(0, tipHash)
 			if tip.Header.Bits == lastBits {

--- a/domain/consensus/processes/pastmediantimemanager/pastmediantimemanager.go
+++ b/domain/consensus/processes/pastmediantimemanager/pastmediantimemanager.go
@@ -11,7 +11,7 @@ import (
 // pastMedianTimeManager provides a method to resolve the
 // past median time of a block
 type pastMedianTimeManager struct {
-	timestampDeviationTolerance uint64
+	timestampDeviationTolerance int
 
 	databaseContext model.DBReader
 
@@ -22,7 +22,7 @@ type pastMedianTimeManager struct {
 }
 
 // New instantiates a new PastMedianTimeManager
-func New(timestampDeviationTolerance uint64,
+func New(timestampDeviationTolerance int,
 	databaseContext model.DBReader,
 	dagTraversalManager model.DAGTraversalManager,
 	blockHeaderStore model.BlockHeaderStore,

--- a/domain/dagconfig/params.go
+++ b/domain/dagconfig/params.go
@@ -98,11 +98,11 @@ type Params struct {
 
 	// TimestampDeviationTolerance is the maximum offset a block timestamp
 	// is allowed to be in the future before it gets delayed
-	TimestampDeviationTolerance uint64
+	TimestampDeviationTolerance int
 
 	// DifficultyAdjustmentWindowSize is the size of window that is inspected
 	// to calculate the required difficulty of each block.
-	DifficultyAdjustmentWindowSize uint64
+	DifficultyAdjustmentWindowSize int
 
 	// These fields are related to voting on consensus rule changes as
 	// defined by BIP0009.

--- a/infrastructure/config/network.go
+++ b/infrastructure/config/network.go
@@ -39,8 +39,8 @@ type overrideDAGParamsConfig struct {
 	SubsidyReductionInterval                *uint64      `json:"subsidyReductionInterval"`
 	TargetTimePerBlockInMilliSeconds        *int64       `json:"targetTimePerBlockInMilliSeconds"`
 	FinalityDuration                        *int64       `json:"finalityDuration"`
-	TimestampDeviationTolerance             *uint64      `json:"timestampDeviationTolerance"`
-	DifficultyAdjustmentWindowSize          *uint64      `json:"difficultyAdjustmentWindowSize"`
+	TimestampDeviationTolerance             *int         `json:"timestampDeviationTolerance"`
+	DifficultyAdjustmentWindowSize          *int         `json:"difficultyAdjustmentWindowSize"`
 	RelayNonStdTxs                          *bool        `json:"relayNonStdTxs"`
 	AcceptUnroutable                        *bool        `json:"acceptUnroutable"`
 	EnableNonNativeSubnetworks              *bool        `json:"enableNonNativeSubnetworks"`


### PR DESCRIPTION
This resolves #1022, basically until now we only used blue blocks in the DAA, instead we made 2 changes:
1. We pick all blocks for the window.
2. We order them by BlueWork, not by BFS or blueScore (this is implicitly changed by #1172).

2 important notes here:
1. For every `B` `B.SelectedParent` has the highest blueWork out of all of the blocks in `B.Past`, so if we go down the SelectedChain we always have the SP as the block with highest blueWork.
2. A block in the merge set can have lower blueWork than a block lower in the SelectedChain.

Because of 1 we can stop searching for higher blueWork if the next SP has lower blueWork than the minimal block in the window(and the window is full).
And because of 2 we need to keep going down the SelectedChain even if we already "filled" the window, until the sentence above is true.

Also, because the mergeSet is ordered we can stop adding to the window if the last block in the merge set failed adding.

Also note that we treat blue and red blocks equally here, resulting in 1 block per second, not 1 blue block per second.