### PR TITLE
Parallelize all the tests using ForAllNets (cut test time by half)

### DIFF
--- a/domain/consensus/utils/testutils/for_all_nets.go
+++ b/domain/consensus/utils/testutils/for_all_nets.go
@@ -18,8 +18,11 @@ func ForAllNets(t *testing.T, skipPow bool, testFunc func(*testing.T, *dagconfig
 
 	for _, params := range allParams {
 		paramsCopy := params
-		paramsCopy.SkipProofOfWork = skipPow
-		t.Logf("Running test for %s", params.Name)
-		testFunc(t, &paramsCopy)
+		t.Run(paramsCopy.Name, func(t *testing.T) {
+			t.Parallel()
+			paramsCopy.SkipProofOfWork = skipPow
+			t.Logf("Running test for %s", paramsCopy.Name)
+			testFunc(t, &paramsCopy)
+		})
 	}
 }


### PR DESCRIPTION
This uses `t.Run(...)` which runs a "Subtest" in a separate goroutine https://golang.org/pkg/testing/#T.Run
It also uses `t.Parallel()` to mark those as parallelizable https://golang.org/pkg/testing/#T.Parallel
without `t.Parallel()` go launches every test in its own go routine *but* it then blocks until the test is done, `t.Parallel()` allows it to unblock the main thread that launches the tests.

the amount of parallelization is determined by `-cpu=N` with `GOMAXPROCS` as default.

on my machine, locked on 2.4ghz with `hyperfine --warmup 2 'go test -count=1 ./...'` I get before:
```
Benchmark #1: go test -count=1 ./...
  Time (mean ± σ):     46.621 s ±  0.555 s    [User: 89.440 s, System: 11.110 s]
  Range (min … max):   46.054 s … 47.476 s    10 runs
```
After:
```
Benchmark #1: go test -count=1 ./...
  Time (mean ± σ):     20.363 s ±  0.469 s    [User: 101.681 s, System: 12.587 s]
  Range (min … max):   19.587 s … 20.971 s    10 runs
```

The `-count=1` was needed to prevent `go test` from just caching the result of the tests, See: https://golang.org/cmd/go
> When 'go test' runs in package list mode, 'go test' caches successful package test results to avoid unnecessary repeated running of tests. To disable test caching, use any test flag or argument other than the cacheable flags. The idiomatic way to disable test caching explicitly is to use -count=1. 

And: https://golang.org/cmd/go/#hdr-Testing_flags
> -count n
    Run each test and benchmark n times (default 1).
    If -cpu is set, run n times for each GOMAXPROCS value.
    Examples are always run once.