### PR TITLE
Limit the orphan collection

### DIFF
--- a/app/protocol/flowcontext/orphans.go
+++ b/app/protocol/flowcontext/orphans.go
@@ -9,8 +9,8 @@ import (
 
 // maxOrphans is the maximum amount of orphans allowed in the
 // orphans collection. This number is an approximation of how
-// many orphans there can possibly be in an average case. It
-// is based on: 2^orphanResolutionRange * PHANTOM K.
+// many orphans there can possibly be on average. It is based
+// on: 2^orphanResolutionRange * PHANTOM K.
 const maxOrphans = 600
 
 // AddOrphan adds the block to the orphan set
@@ -23,19 +23,20 @@ func (f *FlowContext) AddOrphan(orphanBlock *externalapi.DomainBlock) {
 
 	if len(f.orphans) > maxOrphans {
 		log.Debugf("Orphan collection size exceeded. Evicting a random orphan")
-		f.removeRandomOrphan()
+		f.evictRandomOrphan()
 	}
 
 	log.Infof("Received a block with missing parents, adding to orphan pool: %s", orphanHash)
 }
 
-func (f *FlowContext) removeRandomOrphan() {
-	var toRemove externalapi.DomainHash
+func (f *FlowContext) evictRandomOrphan() {
+	var toEvict externalapi.DomainHash
 	for hash := range f.orphans {
-		toRemove = hash
+		toEvict = hash
 		break
 	}
-	delete(f.orphans, toRemove)
+	delete(f.orphans, toEvict)
+	log.Debugf("Evicted %s from the orphan collection")
 }
 
 // IsOrphan returns whether the given blockHash belongs to an orphan block

--- a/app/protocol/flowcontext/orphans.go
+++ b/app/protocol/flowcontext/orphans.go
@@ -36,7 +36,7 @@ func (f *FlowContext) evictRandomOrphan() {
 		break
 	}
 	delete(f.orphans, toEvict)
-	log.Debugf("Evicted %s from the orphan collection")
+	log.Debugf("Evicted %s from the orphan collection", toEvict)
 }
 
 // IsOrphan returns whether the given blockHash belongs to an orphan block


### PR DESCRIPTION
This fixes issue https://github.com/kaspanet/kaspad/issues/1208

Currently the orphans collection is unbound.
This PR sets an upper bound to this collection based on the following equation: `2^orphanResolutionRange * PHANTOM K`, which should be a good approximation of the maximum possible collection size in the average case.