### PR TITLE
Add safeguard against running TestDifficulty with a fresh genesis block

### DIFF
--- a/domain/consensus/processes/blockvalidator/block_header_in_isolation.go
+++ b/domain/consensus/processes/blockvalidator/block_header_in_isolation.go
@@ -47,7 +47,6 @@ func (v *blockValidator) checkParentsLimit(header *externalapi.DomainBlockHeader
 }
 
 func (v *blockValidator) checkBlockTimestampInIsolation(header *externalapi.DomainBlockHeader) error {
-
 	blockTimestamp := header.TimeInMilliseconds
 	now := mstime.Now().UnixMilliseconds()
 	maxCurrentTime := now + int64(v.timestampDeviationTolerance)*v.targetTimePerBlock.Milliseconds()

--- a/domain/consensus/processes/difficultymanager/difficultymanager_test.go
+++ b/domain/consensus/processes/difficultymanager/difficultymanager_test.go
@@ -2,6 +2,9 @@ package difficultymanager_test
 
 import (
 	"testing"
+	"time"
+
+	"github.com/kaspanet/kaspad/util/mstime"
 
 	"github.com/kaspanet/kaspad/domain/consensus/utils/consensushashing"
 
@@ -18,6 +21,14 @@ func TestDifficulty(t *testing.T) {
 		if params.DisableDifficultyAdjustment {
 			return
 		}
+		// This test generates 3066 blocks above genesis with at least 1 second between each block, amounting to
+		// a bit less then an hour of timestamps.
+		// To prevent rejected blocks due to timestamps in the future, the following safeguard makes sure
+		// the genesis block is at least 1 hour in the past.
+		if params.GenesisBlock.Header.TimeInMilliseconds > mstime.ToMSTime(time.Now().Add(-time.Hour)).UnixMilliseconds() {
+			t.Fatalf("TestDifficulty requires the GenesisBlock to be at least 1 hour old to pass")
+		}
+
 		params.K = 1
 		params.DifficultyAdjustmentWindowSize = 264
 


### PR DESCRIPTION
TestGenesis test generates 3066 blocks above genesis with at least 1 second between each block, amounting to a bit less then an hour of timestamps.
To prevent rejected blocks due to timestamps in the future, this PR adds safeguard that makes sure the genesis block is at least 1 hour in the past.

Closes #1191 