### PR TITLE
Fix the Sequence field in transaction inputs always getting deserialized to MaxUint64

### DIFF
--- a/app/appmessage/p2p_msgtx.go
+++ b/app/appmessage/p2p_msgtx.go
@@ -9,8 +9,6 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/utils/hashes"
 	"strconv"
 
-	"github.com/kaspanet/kaspad/domain/consensus/utils/constants"
-
 	"github.com/kaspanet/kaspad/domain/consensus/utils/consensushashing"
 
 	"github.com/kaspanet/kaspad/domain/consensus/utils/subnetworks"
@@ -98,11 +96,11 @@ type TxIn struct {
 // NewTxIn returns a new kaspa transaction input with the provided
 // previous outpoint point and signature script with a default sequence of
 // MaxTxInSequenceNum.
-func NewTxIn(prevOut *Outpoint, signatureScript []byte) *TxIn {
+func NewTxIn(prevOut *Outpoint, signatureScript []byte, sequence uint64) *TxIn {
 	return &TxIn{
 		PreviousOutpoint: *prevOut,
 		SignatureScript:  signatureScript,
-		Sequence:         constants.MaxTxInSequenceNum,
+		Sequence:         sequence,
 	}
 }
 

--- a/app/appmessage/p2p_msgtx_test.go
+++ b/app/appmessage/p2p_msgtx_test.go
@@ -7,6 +7,7 @@ package appmessage
 import (
 	"bytes"
 	"fmt"
+	"github.com/kaspanet/kaspad/domain/consensus/utils/constants"
 	"math"
 	"reflect"
 	"testing"
@@ -68,7 +69,7 @@ func TestTx(t *testing.T) {
 
 	// Ensure we get the same transaction input back out.
 	sigScript := []byte{0x04, 0x31, 0xdc, 0x00, 0x1b, 0x01, 0x62}
-	txIn := NewTxIn(prevOut, sigScript)
+	txIn := NewTxIn(prevOut, sigScript, constants.MaxTxInSequenceNum)
 	if !reflect.DeepEqual(&txIn.PreviousOutpoint, prevOut) {
 		t.Errorf("NewTxIn: wrong prev outpoint - got %v, want %v",
 			spew.Sprint(&txIn.PreviousOutpoint),

--- a/infrastructure/network/netadapter/server/grpcserver/protowire/p2p_transaction.go
+++ b/infrastructure/network/netadapter/server/grpcserver/protowire/p2p_transaction.go
@@ -25,7 +25,7 @@ func (x *TransactionMessage) toAppMessage() (appmessage.Message, error) {
 		}
 
 		outpoint := appmessage.NewOutpoint(prevTxID, protoInput.PreviousOutpoint.Index)
-		inputs[i] = appmessage.NewTxIn(outpoint, protoInput.SignatureScript)
+		inputs[i] = appmessage.NewTxIn(outpoint, protoInput.SignatureScript, protoInput.Sequence)
 	}
 
 	outputs := make([]*appmessage.TxOut, len(x.Outputs))

--- a/testing/integration/tx_relay_test.go
+++ b/testing/integration/tx_relay_test.go
@@ -88,7 +88,7 @@ func waitForPayeeToReceiveBlock(t *testing.T, payeeBlockAddedChan chan *appmessa
 
 func generateTx(t *testing.T, firstBlockCoinbase *externalapi.DomainTransaction, payer, payee *appHarness) *appmessage.MsgTx {
 	txIns := make([]*appmessage.TxIn, 1)
-	txIns[0] = appmessage.NewTxIn(appmessage.NewOutpoint(consensushashing.TransactionID(firstBlockCoinbase), 0), []byte{})
+	txIns[0] = appmessage.NewTxIn(appmessage.NewOutpoint(consensushashing.TransactionID(firstBlockCoinbase), 0), []byte{}, 0)
 
 	payeeAddress, err := util.DecodeAddress(payee.miningAddress, util.Bech32PrefixKaspaSim)
 	if err != nil {

--- a/testing/integration/utxo_index_test.go
+++ b/testing/integration/utxo_index_test.go
@@ -151,7 +151,7 @@ func buildTransactionForUTXOIndexTest(t *testing.T, entry *appmessage.UTXOsByAdd
 	}
 
 	txIns := make([]*appmessage.TxIn, 1)
-	txIns[0] = appmessage.NewTxIn(appmessage.NewOutpoint(transactionID, entry.Outpoint.Index), []byte{})
+	txIns[0] = appmessage.NewTxIn(appmessage.NewOutpoint(transactionID, entry.Outpoint.Index), []byte{}, 0)
 
 	payeeAddress, err := util.DecodeAddress(miningAddress1, util.Bech32PrefixKaspaSim)
 	if err != nil {


### PR DESCRIPTION
This PR fixed a bug in which, in deserialization, the Sequence field in MsgTx inputs was always initialized to MaxUint64 and never changed.
See: infrastructure/network/netadapter/server/grpcserver/protowire/p2p_transaction.go line 28.