### PR TITLE
Fix AddBlock not returning validation failure errors

### DIFF
--- a/app/protocol/flowcontext/blocks.go
+++ b/app/protocol/flowcontext/blocks.go
@@ -102,7 +102,6 @@ func (f *FlowContext) AddBlock(block *externalapi.DomainBlock) error {
 	if err != nil {
 		if errors.As(err, &ruleerrors.RuleError{}) {
 			log.Infof("Validation failed for block %s: %s", consensushashing.BlockHash(block), err)
-			return nil
 		}
 		return err
 	}

--- a/app/protocol/flowcontext/blocks.go
+++ b/app/protocol/flowcontext/blocks.go
@@ -101,7 +101,7 @@ func (f *FlowContext) AddBlock(block *externalapi.DomainBlock) error {
 	blockInsertionResult, err := f.Domain().Consensus().ValidateAndInsertBlock(block)
 	if err != nil {
 		if errors.As(err, &ruleerrors.RuleError{}) {
-			log.Infof("Validation failed for block %s: %s", consensushashing.BlockHash(block), err)
+			log.Warnf("Validation failed for block %s: %s", consensushashing.BlockHash(block), err)
 		}
 		return err
 	}

--- a/app/protocol/flowcontext/orphans.go
+++ b/app/protocol/flowcontext/orphans.go
@@ -149,7 +149,7 @@ func (f *FlowContext) unorphanBlock(orphanHash externalapi.DomainHash) (*externa
 	blockInsertionResult, err := f.domain.Consensus().ValidateAndInsertBlock(orphanBlock)
 	if err != nil {
 		if errors.As(err, &ruleerrors.RuleError{}) {
-			log.Infof("Validation failed for orphan block %s: %s", orphanHash, err)
+			log.Warnf("Validation failed for orphan block %s: %s", orphanHash, err)
 			return nil, nil
 		}
 		return nil, err

--- a/app/rpc/rpchandlers/submit_block.go
+++ b/app/rpc/rpchandlers/submit_block.go
@@ -3,8 +3,10 @@ package rpchandlers
 import (
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/kaspanet/kaspad/app/rpc/rpccontext"
+	"github.com/kaspanet/kaspad/domain/consensus/ruleerrors"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/consensushashing"
 	"github.com/kaspanet/kaspad/infrastructure/network/netadapter/router"
+	"github.com/pkg/errors"
 )
 
 // HandleSubmitBlock handles the respectively named RPC command
@@ -16,6 +18,9 @@ func HandleSubmitBlock(context *rpccontext.Context, _ *router.Router, request ap
 
 	err := context.ProtocolManager.AddBlock(domainBlock)
 	if err != nil {
+		if !errors.As(err, &ruleerrors.RuleError{}) {
+			return nil, err
+		}
 		errorMessage := &appmessage.SubmitBlockResponseMessage{}
 		errorMessage.Error = appmessage.RPCErrorf("Block rejected. Reason: %s", err)
 		return errorMessage, nil


### PR DESCRIPTION
Currently, AddBlock swallows RuleErrors and prints them to the log.
This causes SubmitBlock (the RPC method) to never report back to the client that their block was rejected.