### PR TITLE
Increase size of reachability and block-relations cache

### DIFF
--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -74,7 +74,7 @@ func (f *factory) NewConsensus(dagParams *dagconfig.Params, db infrastructuredat
 	if err != nil {
 		return nil, err
 	}
-	blockRelationStore := blockrelationstore.New(200)
+	blockRelationStore := blockrelationstore.New(10_000)
 	blockStatusStore := blockstatusstore.New(200)
 	multisetStore := multisetstore.New(200)
 	pruningStore := pruningstore.New()

--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -78,7 +78,7 @@ func (f *factory) NewConsensus(dagParams *dagconfig.Params, db infrastructuredat
 	blockStatusStore := blockstatusstore.New(200)
 	multisetStore := multisetstore.New(200)
 	pruningStore := pruningstore.New()
-	reachabilityDataStore := reachabilitydatastore.New(200)
+	reachabilityDataStore := reachabilitydatastore.New(10_000)
 	utxoDiffStore := utxodiffstore.New(200)
 	consensusStateStore := consensusstatestore.New()
 	ghostdagDataStore := ghostdagdatastore.New(10_000)


### PR DESCRIPTION
This increases the size of the reachability and block-relations data-stores cache to 10,000 items, to accommodate csm.mergeSetIncrease