### PR TITLE
Fix transaction relay not working

### DIFF
--- a/app/protocol/flows/transactionrelay/handle_relayed_transactions.go
+++ b/app/protocol/flows/transactionrelay/handle_relayed_transactions.go
@@ -168,7 +168,7 @@ func (flow *handleRelayedTransactionsFlow) receiveTransactions(requestedTransact
 		}
 		tx := appmessage.MsgTxToDomainTransaction(msgTx)
 		txID := consensushashing.TransactionID(tx)
-		if txID != expectedID {
+		if !txID.Equal(expectedID) {
 			return protocolerrors.Errorf(true, "expected transaction %s, but got %s",
 				expectedID, txID)
 		}

--- a/testing/integration/tx_relay_test.go
+++ b/testing/integration/tx_relay_test.go
@@ -60,7 +60,7 @@ func TestTxRelay(t *testing.T) {
 		for range ticker.C {
 			_, err := payee.rpcClient.GetMempoolEntry(txID)
 			if err != nil {
-				if strings.Contains(err.Error(), "transaction is not in the pool") {
+				if strings.Contains(err.Error(), "not found") {
 					continue
 				}
 


### PR DESCRIPTION
This PR fixes https://github.com/kaspanet/kaspad/issues/1277

The fix is twofold:
* TestTxRelay calls the getMempoolEntry RPC command to check whether a transaction has been added to the mempool of some node. GetMempoolEntry was unimplemented
* There was a faulty equality check in the transaction relay flow that rejected all relayed transactions