### PR TITLE
Fix deletePastBlocks to check reachability using virtual parents

### DIFF
--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -198,7 +198,14 @@ func (pm *pruningManager) deletePastBlocks(pruningPoint *externalapi.DomainHash)
 			return err
 		}
 		if !hasPruningPointInPast {
-			isInVirtualPast, err := pm.dagTopologyManager.IsAncestorOf(model.VirtualBlockHash, tip)
+			virtualParents, err := pm.dagTopologyManager.Parents(model.VirtualBlockHash)
+			if err != nil {
+				return err
+			}
+
+			// Because virtual doesn't have reachability data, we need to check reachability
+			// using it parents.
+			isInVirtualPast, err := pm.dagTopologyManager.IsAncestorOfAny(tip, virtualParents)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
There's a bug in `func (pm *pruningManager) deletePastBlocks` where it checks virtual reachability using `pm.dagTopologyManager.IsAncestorOf`, but it's impossible because virtual doesn't have reachability data. So instead we should check its reachability with `pm.dagTopologyManager.IsAncestorOfAny(tip, virtualParents)`