### PR TITLE
Fill testConsensus's dagParams

### DIFF
--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -375,6 +375,7 @@ func (f *factory) NewTestConsensusWithDataDir(dagParams *dagconfig.Params, dataD
 	testTransactionValidator := transactionvalidator.NewTestTransactionValidator(consensusAsImplementation.transactionValidator)
 
 	tstConsensus := &testConsensus{
+		dagParams:                 dagParams,
 		consensus:                 consensusAsImplementation,
 		testConsensusStateManager: testConsensusStateManager,
 		testReachabilityManager: reachabilitymanager.NewTestReachabilityManager(consensusAsImplementation.


### PR DESCRIPTION
testConsensus.dagParams was always empty