### PR TITLE
Make only one transaction in validateAndInsertBlock

### DIFF
--- a/domain/consensus/processes/blockprocessor/validateandinsertblock.go
+++ b/domain/consensus/processes/blockprocessor/validateandinsertblock.go
@@ -66,13 +66,6 @@ func (bp *blockProcessor) validateAndInsertBlock(block *externalapi.DomainBlock,
 		return nil, err
 	}
 
-	// Block validations passed, save whatever DAG data was
-	// collected so far
-	err = bp.commitAllChanges()
-	if err != nil {
-		return nil, err
-	}
-
 	var oldHeadersSelectedTip *externalapi.DomainHash
 	isGenesis := blockHash.Equal(bp.genesisHash)
 	if !isGenesis {


### PR DESCRIPTION
Currently there are two transactions in validateAndInsertBlock, but it added unnecessary complexity to the system, and can create inconsistent state. In order to avoid a complex recovery mechanism, I just combined the two transactions so validateAndInsertBlock will be entirely atomic.