### PR TITLE
Move version initializiation to init function to prevent race conditions

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -21,8 +21,7 @@ var appBuild string
 
 var version = "" // string used for memoization of version
 
-// Version returns the application version as a properly formed string
-func Version() string {
+func init() {
 	if version == "" {
 		// Start with the major, minor, and patch versions.
 		version = fmt.Sprintf("%d.%d.%d", appMajor, appMinor, appPatch)
@@ -35,7 +34,10 @@ func Version() string {
 			version = fmt.Sprintf("%s-%s", version, appBuild)
 		}
 	}
+}
 
+// Version returns the application version as a properly formed string
+func Version() string {
 	return version
 }
 


### PR DESCRIPTION
Currently if 2 go-routines call `Version()` for the first time at the same time there will be a race condition.

this fixes it (we can't init them inline because that will prevent using the `'-ldflags "-X github.com/kaspanet/kaspad/version.appBuild=foo"` feature from line 17) 