### PR TITLE
Set stream max message size and increase the max message size to 1GB

### DIFF
--- a/app/protocol/flows/blockrelay/ibd.go
+++ b/app/protocol/flows/blockrelay/ibd.go
@@ -53,6 +53,7 @@ func (flow *handleRelayInvsFlow) runIBDIfNotRunning(highHash *externalapi.Domain
 	}
 
 	if blockInfo.BlockStatus == externalapi.StatusHeaderOnly {
+		log.Infof("Checking if the suggested pruning point %s is compatible to the node DAG", msgIBDRootHash.Hash)
 		isValid, err := flow.Domain().Consensus().IsValidPruningPoint(msgIBDRootHash.Hash)
 		if err != nil {
 			return err

--- a/infrastructure/network/netadapter/server/grpcserver/grpc_server.go
+++ b/infrastructure/network/netadapter/server/grpcserver/grpc_server.go
@@ -18,7 +18,7 @@ type gRPCServer struct {
 }
 
 // MaxMessageSize is the max size allowed for a message
-const MaxMessageSize = 1024 * 1024 * 10 // 10MB
+const MaxMessageSize = 1024 * 1024 * 1024 // 1GB
 
 // newGRPCServer creates a gRPC server
 func newGRPCServer(listeningAddresses []string) *gRPCServer {

--- a/infrastructure/network/netadapter/server/grpcserver/p2pserver.go
+++ b/infrastructure/network/netadapter/server/grpcserver/p2pserver.go
@@ -47,7 +47,8 @@ func (p *p2pServer) Connect(address string) (server.Connection, error) {
 	}
 
 	client := protowire.NewP2PClient(gRPCClientConnection)
-	stream, err := client.MessageStream(context.Background(), grpc.UseCompressor(gzip.Name))
+	stream, err := client.MessageStream(context.Background(), grpc.UseCompressor(gzip.Name),
+		grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting client stream for %s", address)
 	}


### PR DESCRIPTION
P2P gRPC client connections had the default max message size by accident, so I fixed it to use the same limit as the server.
In addition, I changed the max message size to 1gb to allow big pruning UTXO set messages.