### PR TITLE
Use sync rate for getBlockTemplate's isSynced

### DIFF
--- a/app/protocol/flowcontext/blocks.go
+++ b/app/protocol/flowcontext/blocks.go
@@ -23,6 +23,8 @@ func (f *FlowContext) OnNewBlock(block *externalapi.DomainBlock,
 	hash := consensushashing.BlockHash(block)
 	log.Debugf("OnNewBlock start for block %s", hash)
 	defer log.Debugf("OnNewBlock end for block %s", hash)
+
+	f.updateRecentBlockAddedTimesWithLastBlock()
 	unorphaningResults, err := f.UnorphanBlocks(block)
 	if err != nil {
 		return err

--- a/app/protocol/flowcontext/flow_context.go
+++ b/app/protocol/flowcontext/flow_context.go
@@ -1,6 +1,7 @@
 package flowcontext
 
 import (
+	"github.com/kaspanet/kaspad/util/mstime"
 	"sync"
 	"time"
 
@@ -34,6 +35,11 @@ type FlowContext struct {
 	domain            domain.Domain
 	addressManager    *addressmanager.AddressManager
 	connectionManager *connmanager.ConnectionManager
+
+	recentBlockAddedTimes      []int64
+	recentBlockAddedTimesMutex sync.Mutex
+
+	timeStarted int64
 
 	onBlockAddedToDAGHandler           OnBlockAddedToDAGHandler
 	onTransactionAddedToMempoolHandler OnTransactionAddedToMempoolHandler
@@ -69,6 +75,7 @@ func New(cfg *config.Config, domain domain.Domain, addressManager *addressmanage
 		peers:                       make(map[id.ID]*peerpkg.Peer),
 		transactionsToRebroadcast:   make(map[externalapi.DomainTransactionID]*externalapi.DomainTransaction),
 		orphans:                     make(map[externalapi.DomainHash]*externalapi.DomainBlock),
+		timeStarted:                 mstime.Now().UnixMilliseconds(),
 	}
 }
 

--- a/app/protocol/flowcontext/orphans.go
+++ b/app/protocol/flowcontext/orphans.go
@@ -154,6 +154,7 @@ func (f *FlowContext) unorphanBlock(orphanHash externalapi.DomainHash) (*externa
 		}
 		return nil, err
 	}
+	f.updateRecentBlockAddedTimesWithLastBlock()
 
 	log.Infof("Unorphaned block %s", orphanHash)
 	return blockInsertionResult, nil

--- a/app/protocol/flowcontext/sync_rate.go
+++ b/app/protocol/flowcontext/sync_rate.go
@@ -4,7 +4,7 @@ import "github.com/kaspanet/kaspad/util/mstime"
 
 const (
 	syncRateWindowInMilliSeconds                         = 60_000
-	syncRatMaxDeviation                                  = 0.05
+	syncRateMaxDeviation                                 = 0.05
 	maxSelectedParentTimeDiffToAllowMiningInMilliSeconds = 300_000
 )
 
@@ -44,7 +44,7 @@ func (f *FlowContext) isSyncRateBelowMinimum() bool {
 	}
 
 	expectedBlocks := float64(syncRateWindowInMilliSeconds) / float64(f.cfg.NetParams().TargetTimePerBlock.Milliseconds())
-	return 1-float64(len(f.recentBlockAddedTimes))/expectedBlocks > syncRatMaxDeviation
+	return 1-float64(len(f.recentBlockAddedTimes))/expectedBlocks > syncRateMaxDeviation
 }
 
 // ShouldMine returns whether it's ok to use block template from this node

--- a/app/protocol/flowcontext/sync_rate.go
+++ b/app/protocol/flowcontext/sync_rate.go
@@ -1,0 +1,78 @@
+package flowcontext
+
+import "github.com/kaspanet/kaspad/util/mstime"
+
+const (
+	syncRateWindowInMilliSeconds                         = 60_000
+	syncRatMaxDeviation                                  = 0.05
+	maxSelectedParentTimeDiffToAllowMiningInMilliSeconds = 300_000
+)
+
+func (f *FlowContext) updateRecentBlockAddedTimesWithLastBlock() {
+	f.recentBlockAddedTimesMutex.Lock()
+	defer f.recentBlockAddedTimesMutex.Unlock()
+
+	f.removeOldBlockTimes()
+	f.recentBlockAddedTimes = append(f.recentBlockAddedTimes, mstime.Now().UnixMilliseconds())
+}
+
+// removeOldBlockTimes removes from recentBlockAddedTimes block times
+// older than syncRateWindowInMilliSeconds.
+// This function is not safe for concurrent use.
+func (f *FlowContext) removeOldBlockTimes() {
+	now := mstime.Now().UnixMilliseconds()
+	mostRecentBlockToKeep := 0
+	for i, blockAddedTime := range f.recentBlockAddedTimes {
+		if now-syncRateWindowInMilliSeconds < blockAddedTime {
+			mostRecentBlockToKeep = i
+			break
+		}
+	}
+	f.recentBlockAddedTimes = f.recentBlockAddedTimes[mostRecentBlockToKeep:]
+}
+
+func (f *FlowContext) isSyncRateBelowMinimum() bool {
+	f.recentBlockAddedTimesMutex.Lock()
+	defer f.recentBlockAddedTimesMutex.Unlock()
+
+	f.removeOldBlockTimes()
+
+	now := mstime.Now().UnixMilliseconds()
+	timeSinceStart := now - f.timeStarted
+	if timeSinceStart <= syncRateWindowInMilliSeconds {
+		return false
+	}
+
+	expectedBlocks := float64(syncRateWindowInMilliSeconds) / float64(f.cfg.NetParams().TargetTimePerBlock.Milliseconds())
+	return 1-float64(len(f.recentBlockAddedTimes))/expectedBlocks > syncRatMaxDeviation
+}
+
+// ShouldMine returns whether it's ok to use block template from this node
+// for mining purposes.
+func (f *FlowContext) ShouldMine() (bool, error) {
+	if f.isSyncRateBelowMinimum() {
+		log.Debugf("The sync rate is below the minimum, so ShouldMine returns true")
+		return true, nil
+	}
+
+	if f.IsIBDRunning() {
+		log.Debugf("IBD is running, so ShouldMine returns false")
+		return false, nil
+	}
+
+	virtualSelectedParent, err := f.domain.Consensus().GetVirtualSelectedParent()
+	if err != nil {
+		return false, err
+	}
+
+	now := mstime.Now().UnixMilliseconds()
+	if now-virtualSelectedParent.Header.TimeInMilliseconds < maxSelectedParentTimeDiffToAllowMiningInMilliSeconds {
+		log.Debugf("The selected tip timestamp is recent (%d), so ShouldMine returns true",
+			virtualSelectedParent.Header.TimeInMilliseconds)
+		return true, nil
+	}
+
+	log.Debugf("The selected tip timestamp is old (%d), so ShouldMine returns false",
+		virtualSelectedParent.Header.TimeInMilliseconds)
+	return false, nil
+}

--- a/app/protocol/manager.go
+++ b/app/protocol/manager.go
@@ -68,7 +68,8 @@ func (m *Manager) SetOnTransactionAddedToMempoolHandler(onTransactionAddedToMemp
 	m.context.SetOnTransactionAddedToMempoolHandler(onTransactionAddedToMempoolHandler)
 }
 
-// IsIBDRunning returns true if IBD is currently running
-func (m *Manager) IsIBDRunning() bool {
-	return m.context.IsIBDRunning()
+// ShouldMine returns whether it's ok to use block template from this node
+// for mining purposes.
+func (m *Manager) ShouldMine() (bool, error) {
+	return m.context.ShouldMine()
 }

--- a/app/rpc/rpchandlers/get_block_template.go
+++ b/app/rpc/rpchandlers/get_block_template.go
@@ -33,7 +33,10 @@ func HandleGetBlockTemplate(context *rpccontext.Context, _ *router.Router, reque
 	}
 	msgBlock := appmessage.DomainBlockToMsgBlock(templateBlock)
 
-	isSynced := !context.ProtocolManager.IsIBDRunning()
+	isSynced, err := context.ProtocolManager.ShouldMine()
+	if err != nil {
+		return nil, err
+	}
 
 	return appmessage.NewGetBlockTemplateResponseMessage(msgBlock, isSynced), nil
 }


### PR DESCRIPTION
In order to avoid mining red blocks from an non synced node, we want to give an indication in getBlockTemplate whether the node is synced.

This PR tries to define better whether the node is synced or not. We use the following indications:
1) If we're during IBD it means we're not synced, so we don't mine.
2) If our selected tip timestamp is not current, it means we'll probably enter IBD soon, so we don't mine.

But this two indications have some problems:
1) An attacker can mislead us to think we're behind by sending us an orphan blocks that can be very easily produced, because we can't validate its difficulty. This will prevent us from mining.
2) If for some reason the mining halts (because a bug in other miners or any other reason), the mining will be freezed forever because the selected tip timestamp will not be recent.

So to avoid those problems we add a third rule:
If the node recently added less blocks to the DAG than the expected with the network block rate, mine anyway.