### PR TITLE
Slightly improve the performance of antiPastHashesBetween

### DIFF
--- a/app/protocol/flows/blockrelay/handle_request_headers.go
+++ b/app/protocol/flows/blockrelay/handle_request_headers.go
@@ -42,7 +42,7 @@ func (flow *handleRequestBlocksFlow) start() error {
 		// We expect that if the other peer did not receive all the headers
 		// they requested, they'd re-request a block locator and re-request
 		// headers with a higher lowHash
-		const maxBlueScoreDifference = 1 << 12
+		const maxBlueScoreDifference = 1 << 10
 		blockHashes, err := flow.Domain().Consensus().GetHashesBetween(lowHash, highHash, maxBlueScoreDifference)
 		if err != nil {
 			return err

--- a/domain/consensus/processes/syncmanager/antipast.go
+++ b/domain/consensus/processes/syncmanager/antipast.go
@@ -35,12 +35,18 @@ func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.Doma
 		// Using blueScore as an approximation is considered to be
 		// fairly accurate because we presume that most DAG blocks are
 		// blue.
-		for highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore()+1 > maxBlueScoreDifference {
-			highHash = highBlockGHOSTDAGData.SelectedParent()
-			var err error
+		iterator, err := sm.dagTraversalManager.SelectedChildIterator(highHash, lowHash)
+		if err != nil {
+			return nil, err
+		}
+		for iterator.Next() {
+			highHash = iterator.Get()
 			highBlockGHOSTDAGData, err = sm.ghostdagDataStore.Get(sm.databaseContext, highHash)
 			if err != nil {
 				return nil, err
+			}
+			if highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore()+1 > maxBlueScoreDifference {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This PR changes two things:
* To find the "limited" high hash in the original high hash's selected parent chain, iterate up from the lowHash instead of down from the highHash
* Further limit maxBlueScoreDifference in handleRequestBlocksFlow from 2^12 to 2^10