### PR TITLE
Reduce the amount of calls to FinalityPoint()

### DIFF
--- a/domain/consensus/processes/mergedepthmanager/merge_depth_manager.go
+++ b/domain/consensus/processes/mergedepthmanager/merge_depth_manager.go
@@ -87,8 +87,12 @@ func (mdm *mergeDepthManager) NonBoundedMergeDepthViolatingBlues(blockHash *exte
 
 	nonBoundedMergeDepthViolatingBlues := make([]*externalapi.DomainHash, 0, len(ghostdagData.MergeSetBlues()))
 
+	finalityPoint, err := mdm.finalityManager.FinalityPoint(blockHash)
+	if err != nil {
+		return nil, err
+	}
 	for _, blue := range ghostdagData.MergeSetBlues() {
-		notViolatingFinality, err := mdm.hasFinalityPointInOthersSelectedChain(blockHash, blue)
+		notViolatingFinality, err := mdm.dagTopologyManager.IsInSelectedParentChainOf(finalityPoint, blue)
 		if err != nil {
 			return nil, err
 		}
@@ -99,13 +103,4 @@ func (mdm *mergeDepthManager) NonBoundedMergeDepthViolatingBlues(blockHash *exte
 	}
 
 	return nonBoundedMergeDepthViolatingBlues, nil
-}
-
-func (mdm *mergeDepthManager) hasFinalityPointInOthersSelectedChain(this, other *externalapi.DomainHash) (bool, error) {
-	finalityPoint, err := mdm.finalityManager.FinalityPoint(this)
-	if err != nil {
-		return false, err
-	}
-
-	return mdm.dagTopologyManager.IsInSelectedParentChainOf(finalityPoint, other)
 }


### PR DESCRIPTION
Right now we call `FinalityPoint()` (getting it from the database/cache) `1+len(MergeSetBlues)` times, instead we can take that call out of the loop and call it only twice. (we could pass the finality point around and only call once but it's already in cache so it doesn't cost too much)