### PR TITLE
Don't print the whole UTXODiff to log, it might be quite huge

### DIFF
--- a/domain/consensus/processes/consensusstatemanager/calculate_past_utxo.go
+++ b/domain/consensus/processes/consensusstatemanager/calculate_past_utxo.go
@@ -68,7 +68,8 @@ func (csm *consensusStateManager) restorePastUTXO(blockHash *externalapi.DomainH
 			return nil, err
 		}
 		utxoDiffs = append(utxoDiffs, utxoDiff)
-		log.Debugf("Collected UTXO diff for block %s: %s", nextBlockHash, utxoDiff)
+		log.Debugf("Collected UTXO diff for block %s: toAdd: %d, toRemove: %d",
+			nextBlockHash, utxoDiff.ToAdd().Len(), utxoDiff.ToRemove().Len())
 
 		exists, err := csm.utxoDiffStore.HasUTXODiffChild(csm.databaseContext, nextBlockHash)
 		if err != nil {


### PR DESCRIPTION
We have a debug log every time a UTXO-Diff for a block is collected.
This have previously log the whole UTXO-Diff, which might be quite huge. Serializing it into a string and writing to the log file is quite a hog.

This PR changes the log to only state the sizes of the utxo-diff's toAdd and toRemove collections.