### PR TITLE
Log only tips length, and inspect ReachabilityData error instead of calling HasReachabilityData

### DIFF
--- a/domain/consensus/processes/consensusstatemanager/add_block_to_virtual.go
+++ b/domain/consensus/processes/consensusstatemanager/add_block_to_virtual.go
@@ -53,7 +53,7 @@ func (csm *consensusStateManager) AddBlock(blockHash *externalapi.DomainHash) (*
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("After adding %s, the new tips are %s", blockHash, newTips)
+	log.Debugf("After adding %s, the amount of new tips are %d", blockHash, len(newTips))
 
 	log.Debugf("Updating the virtual with the new tips")
 	selectedParentChainChanges, err := csm.updateVirtual(blockHash, newTips)
@@ -99,10 +99,9 @@ func (csm *consensusStateManager) addTip(newTipHash *externalapi.DomainHash) (ne
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("The new tips are: %s", newTips)
 
 	csm.consensusStateStore.StageTips(newTips)
-	log.Debugf("Staged the new tips %s", newTips)
+	log.Debugf("Staged the new tips, len: %d", len(newTips))
 
 	return newTips, nil
 }

--- a/domain/consensus/processes/consensusstatemanager/pick_virtual_parents.go
+++ b/domain/consensus/processes/consensusstatemanager/pick_virtual_parents.go
@@ -9,8 +9,8 @@ import (
 )
 
 func (csm *consensusStateManager) pickVirtualParents(tips []*externalapi.DomainHash) ([]*externalapi.DomainHash, error) {
-	log.Debugf("pickVirtualParents start for tips: %s", tips)
-	defer log.Debugf("pickVirtualParents end for tips: %s", tips)
+	log.Debugf("pickVirtualParents start for tips len: %d", len(tips))
+	defer log.Debugf("pickVirtualParents end for tips len: %d", len(tips))
 
 	log.Debugf("Pushing all tips into a DownHeap")
 	candidatesHeap := csm.dagTraversalManager.NewDownHeap()

--- a/domain/consensus/processes/consensusstatemanager/update_virtual.go
+++ b/domain/consensus/processes/consensusstatemanager/update_virtual.go
@@ -21,7 +21,7 @@ func (csm *consensusStateManager) updateVirtual(newBlockHash *externalapi.Domain
 		oldVirtualSelectedParent = oldVirtualGHOSTDAGData.SelectedParent()
 	}
 
-	log.Debugf("Picking virtual parents from the tips: %s", tips)
+	log.Debugf("Picking virtual parents from tips len: %d", len(tips))
 	virtualParents, err := csm.pickVirtualParents(tips)
 	if err != nil {
 		return nil, err

--- a/domain/consensus/processes/reachabilitymanager/fetch.go
+++ b/domain/consensus/processes/reachabilitymanager/fetch.go
@@ -4,25 +4,21 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/reachabilitydata"
+	"github.com/kaspanet/kaspad/infrastructure/db/database"
+	"github.com/pkg/errors"
 )
 
 func (rt *reachabilityManager) reachabilityDataForInsertion(
 	blockHash *externalapi.DomainHash) (model.MutableReachabilityData, error) {
-
-	hasData, err := rt.reachabilityDataStore.HasReachabilityData(rt.databaseContext, blockHash)
-	if err != nil {
-		return nil, err
+	data, err := rt.reachabilityDataStore.ReachabilityData(rt.databaseContext, blockHash)
+	if err == nil {
+		return data.CloneMutable(), nil
 	}
 
-	if !hasData {
+	if errors.Is(err, database.ErrNotFound) {
 		return reachabilitydata.EmptyReachabilityData(), nil
 	}
-
-	data, err := rt.reachabilityDataStore.ReachabilityData(rt.databaseContext, blockHash)
-	if err != nil {
-		return nil, err
-	}
-	return data.CloneMutable(), nil
+	return nil, err
 }
 
 func (rt *reachabilityManager) futureCoveringSet(blockHash *externalapi.DomainHash) (model.FutureCoveringTreeNodeSet, error) {


### PR DESCRIPTION
This should improve the performance of syncing.

Some performance graphs:
![Screenshot_20201229_215107](https://user-images.githubusercontent.com/2167860/103346184-f83bff80-4a9b-11eb-8f2e-4090e2d44387.png)
