### PR TITLE
Remove half the ghostdag store calls in LowestChainBlockAboveOrEqualToBlueScore

### DIFF
--- a/domain/consensus/processes/dagtraversalmanager/dagtraversalmanager.go
+++ b/domain/consensus/processes/dagtraversalmanager/dagtraversalmanager.go
@@ -110,8 +110,7 @@ func (dtm *dagTraversalManager) LowestChainBlockAboveOrEqualToBlueScore(highHash
 
 	currentHash := highHash
 	currentBlockGHOSTDAGData := highBlockGHOSTDAGData
-	iterator := dtm.SelectedParentIterator(highHash)
-	for iterator.Next() {
+	for currentBlockGHOSTDAGData.SelectedParent() != nil {
 		selectedParentBlockGHOSTDAGData, err := dtm.ghostdagDataStore.Get(dtm.databaseContext, currentBlockGHOSTDAGData.SelectedParent())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Currently `LowestChainBlockAboveOrEqualToBlueScore` is using SelectedParentIterator to iterate until genesis (or a break), but then it also uses the ghostdag data, meaning that both it and the iterator call ghostdagdata store.

So by removing the iterator we save 50% of the calls to ghostdagdata store.