### PR TITLE
Check that there are no prefilled fields when validating a block

### DIFF
--- a/domain/consensus/processes/blockbuilder/test_block_builder.go
+++ b/domain/consensus/processes/blockbuilder/test_block_builder.go
@@ -28,6 +28,18 @@ func NewTestBlockBuilder(baseBlockBuilder model.BlockBuilder, testConsensus test
 	}
 }
 
+func cleanBlockPrefilledFields(block *externalapi.DomainBlock) {
+	for _, tx := range block.Transactions {
+		tx.Fee = 0
+		tx.Mass = 0
+		tx.ID = nil
+
+		for _, input := range tx.Inputs {
+			input.UTXOEntry = nil
+		}
+	}
+}
+
 // BuildBlockWithParents builds a block with provided parents, coinbaseData and transactions,
 // and returns the block together with its past UTXO-diff from the virtual.
 func (bb *testBlockBuilder) BuildBlockWithParents(parentHashes []*externalapi.DomainHash,
@@ -37,7 +49,16 @@ func (bb *testBlockBuilder) BuildBlockWithParents(parentHashes []*externalapi.Do
 	onEnd := logger.LogAndMeasureExecutionTime(log, "BuildBlockWithParents")
 	defer onEnd()
 
-	return bb.buildBlockWithParents(parentHashes, coinbaseData, transactions)
+	block, diff, err := bb.buildBlockWithParents(parentHashes, coinbaseData, transactions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// It's invalid to insert a block with prefilled fields to consensus, so we
+	// clean them before returning the block.
+	cleanBlockPrefilledFields(block)
+
+	return block, diff, nil
 }
 
 func (bb *testBlockBuilder) buildHeaderWithParents(parentHashes []*externalapi.DomainHash,

--- a/domain/consensus/test_consensus.go
+++ b/domain/consensus/test_consensus.go
@@ -33,6 +33,18 @@ func (tc *testConsensus) BuildBlockWithParents(parentHashes []*externalapi.Domai
 	return tc.testBlockBuilder.BuildBlockWithParents(parentHashes, coinbaseData, transactions)
 }
 
+func cleanBlockPrefilledFields(block *externalapi.DomainBlock) {
+	for _, tx := range block.Transactions {
+		tx.Fee = 0
+		tx.Mass = 0
+		tx.ID = nil
+
+		for _, input := range tx.Inputs {
+			input.UTXOEntry = nil
+		}
+	}
+}
+
 func (tc *testConsensus) AddBlock(parentHashes []*externalapi.DomainHash, coinbaseData *externalapi.DomainCoinbaseData,
 	transactions []*externalapi.DomainTransaction) (*externalapi.DomainHash, *externalapi.BlockInsertionResult, error) {
 
@@ -44,6 +56,8 @@ func (tc *testConsensus) AddBlock(parentHashes []*externalapi.DomainHash, coinba
 	if err != nil {
 		return nil, nil, err
 	}
+
+	cleanBlockPrefilledFields(block)
 
 	blockInsertionResult, err := tc.blockProcessor.ValidateAndInsertBlock(block)
 	if err != nil {

--- a/domain/consensus/test_consensus.go
+++ b/domain/consensus/test_consensus.go
@@ -22,18 +22,6 @@ func (tc *testConsensus) DAGParams() *dagconfig.Params {
 	return tc.dagParams
 }
 
-func cleanBlockPrefilledFields(block *externalapi.DomainBlock) {
-	for _, tx := range block.Transactions {
-		tx.Fee = 0
-		tx.Mass = 0
-		tx.ID = nil
-
-		for _, input := range tx.Inputs {
-			input.UTXOEntry = nil
-		}
-	}
-}
-
 func (tc *testConsensus) BuildBlockWithParents(parentHashes []*externalapi.DomainHash,
 	coinbaseData *externalapi.DomainCoinbaseData, transactions []*externalapi.DomainTransaction) (
 	*externalapi.DomainBlock, model.UTXODiff, error) {
@@ -46,8 +34,6 @@ func (tc *testConsensus) BuildBlockWithParents(parentHashes []*externalapi.Domai
 	if err != nil {
 		return nil, nil, err
 	}
-
-	cleanBlockPrefilledFields(block)
 
 	return block, diff, nil
 }


### PR DESCRIPTION
We want to validate that when we get a new block in validateAndInsertBlock we don't get it with prefilled "cached" fields such as fee, mass, UTXO entry, etc