### PR TITLE
Remove Windows from the CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-16.04, windows-2019, macos-10.15 ]
+        os: [ ubuntu-16.04, macos-10.15 ]
     name: Testing on on ${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
We're not planing on supporting Windows for Testnet, and Windows on the CI is causing us problems