### PR TITLE
Require only inputs not be prefilled

### DIFF
--- a/domain/consensus/processes/blockprocessor/validateandinsertpruningpoint.go
+++ b/domain/consensus/processes/blockprocessor/validateandinsertpruningpoint.go
@@ -36,14 +36,12 @@ func (bp *blockProcessor) validateAndInsertPruningPoint(newPruningPoint *externa
 
 	log.Infof("Inserting the new pruning point %s", newPruningPointHash)
 	_, err = bp.validateAndInsertBlock(newPruningPoint, true)
-	if err != nil {
-		if errors.As(err, &ruleerrors.RuleError{}) {
-			// This should never happen because we already validated the block with bp.validateBlockAndDiscardChanges.
-			// We use Errorf so it won't be identified later on to be a rule error and will eventually cause
-			// the program to panic.
-			return errors.Errorf("validateAndInsertBlock returned unexpected rule error while processing "+
-				"the pruning point: %+v", err)
-		}
+	if err != nil && errors.As(err, &ruleerrors.RuleError{}) {
+		// This should never happen because we already validated the block with bp.validateBlockAndDiscardChanges.
+		// We use Errorf so it won't be identified later on to be a rule error and will eventually cause
+		// the program to panic.
+		return errors.Errorf("validateAndInsertBlock returned unexpected rule error while processing "+
+			"the pruning point: %+v", err)
 	}
-	return nil
+	return err
 }

--- a/domain/consensus/processes/blockvalidator/block_body_in_isolation.go
+++ b/domain/consensus/processes/blockvalidator/block_body_in_isolation.go
@@ -23,7 +23,7 @@ func (v *blockValidator) ValidateBodyInIsolation(blockHash *externalapi.DomainHa
 		return err
 	}
 
-	err = v.checkNoPrefilledFields(block)
+	err = v.checkNoPrefilledInputs(block)
 	if err != nil {
 		return err
 	}
@@ -230,20 +230,8 @@ func (v *blockValidator) checkBlockSize(block *externalapi.DomainBlock) error {
 	return nil
 }
 
-func (v *blockValidator) checkNoPrefilledFields(block *externalapi.DomainBlock) error {
+func (v *blockValidator) checkNoPrefilledInputs(block *externalapi.DomainBlock) error {
 	for _, tx := range block.Transactions {
-		if tx.Fee != 0 {
-			return errors.Errorf("transaction %s has a prefilled fee", consensushashing.TransactionID(tx))
-		}
-
-		if tx.Mass != 0 {
-			return errors.Errorf("transaction %s has a prefilled mass", consensushashing.TransactionID(tx))
-		}
-
-		if tx.ID != nil {
-			return errors.Errorf("transaction %s has a prefilled ID", consensushashing.TransactionID(tx))
-		}
-
 		for i, input := range tx.Inputs {
 			if input.UTXOEntry != nil {
 				return errors.Errorf("input %d in transaction %s has a prefilled UTXO entry",

--- a/domain/consensus/processes/consensusstatemanager/calculate_past_utxo.go
+++ b/domain/consensus/processes/consensusstatemanager/calculate_past_utxo.go
@@ -115,7 +115,9 @@ func (csm *consensusStateManager) applyMergeSetBlocks(blockHash *externalapi.Dom
 	log.Debugf("applyMergeSetBlocks start for block %s", blockHash)
 	defer log.Tracef("applyMergeSetBlocks end for block %s", blockHash)
 
-	mergeSetBlocks, err := csm.blockStore.Blocks(csm.databaseContext, ghostdagData.MergeSet())
+	mergeSetHashes := ghostdagData.MergeSet()
+	log.Debugf("Merge set for block %s is %v", blockHash, mergeSetHashes)
+	mergeSetBlocks, err := csm.blockStore.Blocks(csm.databaseContext, mergeSetHashes)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/domain/consensus/processes/consensusstatemanager/update_pruning_utxo_set.go
+++ b/domain/consensus/processes/consensusstatemanager/update_pruning_utxo_set.go
@@ -108,7 +108,11 @@ func (csm *consensusStateManager) updatePruningPoint(newPruningPoint *externalap
 	// Before we manually mark the new pruning point as valid, we validate that all of its transactions are valid
 	// against the provided UTXO set.
 	log.Debugf("Validating that the pruning point is UTXO valid")
-	err = csm.validateBlockTransactionsAgainstPastUTXO(newPruningPoint, utxo.NewUTXODiff())
+
+	// validateBlockTransactionsAgainstPastUTXO pre-fills the block's transactions inputs, which
+	// are assumed to not be pre-filled during further validations.
+	// Therefore - clone newPruningPoint before passing it to validateBlockTransactionsAgainstPastUTXO
+	err = csm.validateBlockTransactionsAgainstPastUTXO(newPruningPoint.Clone(), utxo.NewUTXODiff())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes two problems in validateAndInsertPruningPoint:
1. If ValidateAndInsertBlock returned a non-RuleError error - the error was ignored.
2. UpdatePruningPoint fills the data in transactions in the pruning point.