### PR TITLE
Save and expose the database in TestConsensus

### DIFF
--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -379,6 +379,7 @@ func (f *factory) NewTestConsensusWithDataDir(dagParams *dagconfig.Params, dataD
 	tstConsensus := &testConsensus{
 		dagParams:                 dagParams,
 		consensus:                 consensusAsImplementation,
+		database:                  db,
 		testConsensusStateManager: testConsensusStateManager,
 		testReachabilityManager: reachabilitymanager.NewTestReachabilityManager(consensusAsImplementation.
 			reachabilityManager),

--- a/domain/consensus/model/testapi/test_consensus.go
+++ b/domain/consensus/model/testapi/test_consensus.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/dagconfig"
+	"github.com/kaspanet/kaspad/infrastructure/db/database"
 )
 
 // TestConsensus wraps the Consensus interface with some methods that are needed by tests only
@@ -12,6 +13,7 @@ type TestConsensus interface {
 
 	DAGParams() *dagconfig.Params
 	DatabaseContext() model.DBManager
+	Database() database.Database
 
 	BuildBlockWithParents(parentHashes []*externalapi.DomainHash, coinbaseData *externalapi.DomainCoinbaseData,
 		transactions []*externalapi.DomainTransaction) (*externalapi.DomainBlock, model.UTXODiff, error)

--- a/domain/consensus/test_consensus.go
+++ b/domain/consensus/test_consensus.go
@@ -6,11 +6,13 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/model/testapi"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/consensushashing"
 	"github.com/kaspanet/kaspad/domain/dagconfig"
+	"github.com/kaspanet/kaspad/infrastructure/db/database"
 )
 
 type testConsensus struct {
 	*consensus
 	dagParams *dagconfig.Params
+	database  database.Database
 
 	testBlockBuilder          testapi.TestBlockBuilder
 	testReachabilityManager   testapi.TestReachabilityManager

--- a/domain/consensus/test_consensus_getters.go
+++ b/domain/consensus/test_consensus_getters.go
@@ -3,10 +3,15 @@ package consensus
 import (
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/testapi"
+	"github.com/kaspanet/kaspad/infrastructure/db/database"
 )
 
 func (tc *testConsensus) DatabaseContext() model.DBManager {
 	return tc.databaseContext
+}
+
+func (tc *testConsensus) Database() database.Database {
+	return tc.database
 }
 
 func (tc *testConsensus) AcceptanceDataStore() model.AcceptanceDataStore {


### PR DESCRIPTION
This is very useful for creating a `UTXOIndex` which requires a `database.Database` and not a `DBManager`