### PR TITLE
Reverse ghostdag tie break direction

### DIFF
--- a/domain/consensus/model/externalapi/hash.go
+++ b/domain/consensus/model/externalapi/hash.go
@@ -1,6 +1,7 @@
 package externalapi
 
 import (
+	"bytes"
 	"encoding/hex"
 
 	"github.com/pkg/errors"
@@ -106,20 +107,7 @@ func HashesEqual(a, b []*DomainHash) bool {
 	return true
 }
 
-func cmp(a, b *DomainHash) int {
-	// We compare the hashes backwards because Hash is stored as a little endian byte array.
-	for i := DomainHashSize - 1; i >= 0; i-- {
-		switch {
-		case a.hashArray[i] < b.hashArray[i]:
-			return -1
-		case a.hashArray[i] > b.hashArray[i]:
-			return 1
-		}
-	}
-	return 0
-}
-
 // Less returns true iff hash a is less than hash b
 func Less(a, b *DomainHash) bool {
-	return cmp(a, b) < 0
+	return bytes.Compare(a.hashArray[:], b.hashArray[:]) < 0
 }

--- a/domain/consensus/processes/dagtraversalmanager/window_test.go
+++ b/domain/consensus/processes/dagtraversalmanager/window_test.go
@@ -36,12 +36,12 @@ func TestBlueBlockWindow(t *testing.T) {
 				expectedWindowWithGenesisPadding: []string{"B", "A", "A", "A", "A", "A", "A", "A", "A", "A"},
 			},
 			{
-				parents:                          []string{"D", "C"},
+				parents:                          []string{"C", "D"},
 				id:                               "E",
 				expectedWindowWithGenesisPadding: []string{"C", "D", "B", "A", "A", "A", "A", "A", "A", "A"},
 			},
 			{
-				parents:                          []string{"D", "C"},
+				parents:                          []string{"C", "D"},
 				id:                               "F",
 				expectedWindowWithGenesisPadding: []string{"C", "D", "B", "A", "A", "A", "A", "A", "A", "A"},
 			},
@@ -58,37 +58,37 @@ func TestBlueBlockWindow(t *testing.T) {
 			{
 				parents:                          []string{"H", "F"},
 				id:                               "I",
-				expectedWindowWithGenesisPadding: []string{"F", "H", "C", "D", "G", "B", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"F", "C", "D", "H", "G", "B", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"I"},
 				id:                               "J",
-				expectedWindowWithGenesisPadding: []string{"I", "F", "H", "C", "D", "G", "B", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"I", "F", "C", "D", "H", "G", "B", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"J"},
 				id:                               "K",
-				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "H", "C", "D", "G", "B", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "C", "D", "H", "G", "B", "A", "A"},
 			},
 			{
 				parents:                          []string{"K"},
 				id:                               "L",
-				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "H", "C", "D", "G", "B", "A"},
+				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "C", "D", "H", "G", "B", "A"},
 			},
 			{
 				parents:                          []string{"L"},
 				id:                               "M",
-				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "H", "C", "D", "G", "B"},
+				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "C", "D", "H", "G", "B"},
 			},
 			{
 				parents:                          []string{"M"},
 				id:                               "N",
-				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "H", "C", "D", "G"},
+				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "C", "D", "H", "G"},
 			},
 			{
 				parents:                          []string{"N"},
 				id:                               "O",
-				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "H", "C", "D"},
+				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "C", "D", "H"},
 			},
 		},
 		"kaspa-testnet": {
@@ -108,14 +108,14 @@ func TestBlueBlockWindow(t *testing.T) {
 				expectedWindowWithGenesisPadding: []string{"B", "A", "A", "A", "A", "A", "A", "A", "A", "A"},
 			},
 			{
-				parents:                          []string{"D", "C"},
+				parents:                          []string{"C", "D"},
 				id:                               "E",
-				expectedWindowWithGenesisPadding: []string{"D", "C", "B", "A", "A", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"C", "D", "B", "A", "A", "A", "A", "A", "A", "A"},
 			},
 			{
-				parents:                          []string{"D", "C"},
+				parents:                          []string{"C", "D"},
 				id:                               "F",
-				expectedWindowWithGenesisPadding: []string{"D", "C", "B", "A", "A", "A", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"C", "D", "B", "A", "A", "A", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"A"},
@@ -130,37 +130,37 @@ func TestBlueBlockWindow(t *testing.T) {
 			{
 				parents:                          []string{"H", "F"},
 				id:                               "I",
-				expectedWindowWithGenesisPadding: []string{"F", "H", "D", "C", "G", "B", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"F", "C", "H", "D", "G", "B", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"I"},
 				id:                               "J",
-				expectedWindowWithGenesisPadding: []string{"I", "F", "H", "D", "C", "G", "B", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"I", "F", "C", "H", "D", "G", "B", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"J"},
 				id:                               "K",
-				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "H", "D", "C", "G", "B", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "C", "H", "D", "G", "B", "A", "A"},
 			},
 			{
 				parents:                          []string{"K"},
 				id:                               "L",
-				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "H", "D", "C", "G", "B", "A"},
+				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "C", "H", "D", "G", "B", "A"},
 			},
 			{
 				parents:                          []string{"L"},
 				id:                               "M",
-				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "H", "D", "C", "G", "B"},
+				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "C", "H", "D", "G", "B"},
 			},
 			{
 				parents:                          []string{"M"},
 				id:                               "N",
-				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "H", "D", "C", "G"},
+				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "C", "H", "D", "G"},
 			},
 			{
 				parents:                          []string{"N"},
 				id:                               "O",
-				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "H", "D", "C"},
+				expectedWindowWithGenesisPadding: []string{"N", "M", "L", "K", "J", "I", "F", "C", "H", "D"},
 			},
 		},
 		"kaspa-devnet": {
@@ -202,32 +202,32 @@ func TestBlueBlockWindow(t *testing.T) {
 			{
 				parents:                          []string{"H", "F"},
 				id:                               "I",
-				expectedWindowWithGenesisPadding: []string{"F", "D", "H", "C", "G", "B", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"F", "D", "H", "C", "B", "G", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"I"},
 				id:                               "J",
-				expectedWindowWithGenesisPadding: []string{"I", "F", "D", "H", "C", "G", "B", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"I", "F", "D", "H", "C", "B", "G", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"J"},
 				id:                               "K",
-				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "D", "H", "C", "G", "B", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "D", "H", "C", "B", "G", "A", "A"},
 			},
 			{
 				parents:                          []string{"K"},
 				id:                               "L",
-				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "D", "H", "C", "G", "B", "A"},
+				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "D", "H", "C", "B", "G", "A"},
 			},
 			{
 				parents:                          []string{"L"},
 				id:                               "M",
-				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "D", "H", "C", "G", "B"},
+				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "D", "H", "C", "B", "G"},
 			},
 			{
 				parents:                          []string{"M"},
 				id:                               "N",
-				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "D", "H", "C", "G"},
+				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "D", "H", "C", "B"},
 			},
 			{
 				parents:                          []string{"N"},
@@ -274,32 +274,32 @@ func TestBlueBlockWindow(t *testing.T) {
 			{
 				parents:                          []string{"H", "F"},
 				id:                               "I",
-				expectedWindowWithGenesisPadding: []string{"F", "D", "H", "C", "G", "B", "A", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"F", "D", "H", "C", "B", "G", "A", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"I"},
 				id:                               "J",
-				expectedWindowWithGenesisPadding: []string{"I", "F", "D", "H", "C", "G", "B", "A", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"I", "F", "D", "H", "C", "B", "G", "A", "A", "A"},
 			},
 			{
 				parents:                          []string{"J"},
 				id:                               "K",
-				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "D", "H", "C", "G", "B", "A", "A"},
+				expectedWindowWithGenesisPadding: []string{"J", "I", "F", "D", "H", "C", "B", "G", "A", "A"},
 			},
 			{
 				parents:                          []string{"K"},
 				id:                               "L",
-				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "D", "H", "C", "G", "B", "A"},
+				expectedWindowWithGenesisPadding: []string{"K", "J", "I", "F", "D", "H", "C", "B", "G", "A"},
 			},
 			{
 				parents:                          []string{"L"},
 				id:                               "M",
-				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "D", "H", "C", "G", "B"},
+				expectedWindowWithGenesisPadding: []string{"L", "K", "J", "I", "F", "D", "H", "C", "B", "G"},
 			},
 			{
 				parents:                          []string{"M"},
 				id:                               "N",
-				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "D", "H", "C", "G"},
+				expectedWindowWithGenesisPadding: []string{"M", "L", "K", "J", "I", "F", "D", "H", "C", "B"},
 			},
 			{
 				parents:                          []string{"N"},

--- a/domain/consensus/processes/ghostdag2/ghostdagimpl.go
+++ b/domain/consensus/processes/ghostdag2/ghostdagimpl.go
@@ -124,7 +124,7 @@ func ismoreHash(parent *externalapi.DomainHash, selectedParent *externalapi.Doma
 	parentByteArray := parent.ByteArray()
 	selectedParentByteArray := selectedParent.ByteArray()
 	//Check if parentHash is more then selectedParentHash
-	for i := len(parentByteArray) - 1; i >= 0; i-- {
+	for i := 0; i < len(parentByteArray); i++ {
 		switch {
 		case parentByteArray[i] < selectedParentByteArray[i]:
 			return false

--- a/domain/consensus/processes/ghostdagmanager/ghostdag_test.go
+++ b/domain/consensus/processes/ghostdagmanager/ghostdag_test.go
@@ -181,7 +181,7 @@ func TestGHOSTDAG(t *testing.T) {
 func hashesToStrings(arr []*externalapi.DomainHash) []string {
 	var strArr = make([]string, len(arr))
 	for i, hash := range arr {
-		strArr[i] = hash.String()
+		strArr[i] = string(hash.ByteSlice())
 	}
 	return strArr
 }

--- a/domain/consensus/processes/pruningmanager/pruning_test.go
+++ b/domain/consensus/processes/pruningmanager/pruning_test.go
@@ -2,14 +2,15 @@ package pruningmanager_test
 
 import (
 	"encoding/json"
-	"github.com/kaspanet/kaspad/domain/consensus"
-	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
-	"github.com/kaspanet/kaspad/domain/consensus/utils/testutils"
-	"github.com/kaspanet/kaspad/domain/dagconfig"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/kaspanet/kaspad/domain/consensus"
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"github.com/kaspanet/kaspad/domain/consensus/utils/testutils"
+	"github.com/kaspanet/kaspad/domain/dagconfig"
 )
 
 type jsonBlock struct {
@@ -32,10 +33,10 @@ func TestPruning(t *testing.T) {
 			"kaspa-testnet": "1582",
 		},
 		"dag-for-test-pruning.json": {
-			"kaspa-mainnet": "503",
-			"kaspa-simnet":  "503",
-			"kaspa-devnet":  "502",
-			"kaspa-testnet": "503",
+			"kaspa-mainnet": "502",
+			"kaspa-simnet":  "502",
+			"kaspa-devnet":  "503",
+			"kaspa-testnet": "502",
 		},
 	}
 

--- a/domain/consensus/testdata/dags/dag1.json
+++ b/domain/consensus/testdata/dags/dag1.json
@@ -3,7 +3,7 @@
     "GenesisID": "0",
     "Blocks": [
         {
-            "ID": "1111",
+            "ID": "a1",
             "ExpectedScore": 1,
             "ExpectedSelectedParent": "0",
             "ExpectedReds": [],
@@ -41,13 +41,13 @@
         {
             "ID": "4",
             "ExpectedScore": 2,
-            "ExpectedSelectedParent": "1111",
+            "ExpectedSelectedParent": "a1",
             "ExpectedReds": [],
             "ExpectedBlues": [
-                "1111"
+                "a1"
             ],
             "Parents": [
-                "1111"
+                "a1"
             ]
         },
         {
@@ -91,14 +91,14 @@
         {
             "ID": "8",
             "ExpectedScore": 3,
-            "ExpectedSelectedParent": "1111",
+            "ExpectedSelectedParent": "a1",
             "ExpectedReds": [],
             "ExpectedBlues": [
-                "1111",
+                "a1",
                 "2"
             ],
             "Parents": [
-                "1111",
+                "a1",
                 "2"
             ]
         },
@@ -117,7 +117,7 @@
             ]
         },
         {
-            "ID": "10",
+            "ID": "a10",
             "ExpectedScore": 5,
             "ExpectedSelectedParent": "8",
             "ExpectedReds": [],
@@ -147,18 +147,18 @@
         {
             "ID": "12",
             "ExpectedScore": 8,
-            "ExpectedSelectedParent": "10",
+            "ExpectedSelectedParent": "a10",
             "ExpectedReds": [
                 "3",
                 "6"
             ],
             "ExpectedBlues": [
-                "10",
+                "a10",
                 "5",
                 "9"
             ],
             "Parents": [
-                "10",
+                "a10",
                 "9"
             ]
         },
@@ -186,11 +186,11 @@
             ],
             "ExpectedBlues": [
                 "13",
-                "10"
+                "a10"
             ],
             "Parents": [
                 "13",
-                "10"
+                "a10"
             ]
         },
         {
@@ -198,7 +198,7 @@
             "ExpectedScore": 9,
             "ExpectedSelectedParent": "11",
             "ExpectedReds": [
-                "1111",
+                "a1",
                 "8"
             ],
             "ExpectedBlues": [

--- a/domain/consensus/testdata/dags/dag2.json
+++ b/domain/consensus/testdata/dags/dag2.json
@@ -84,8 +84,8 @@
       "ExpectedReds": [],
       "ExpectedBlues": [
         "f154",
-        "d1c",
-        "21d"
+        "21d",
+        "d1c"
       ],
       "Parents": [
         "d1c",


### PR DESCRIPTION
I somehow missed this in #1270.
This is also a small performance improvement(5X for equivalent hashes)

```
goos: linux
goarch: amd64
pkg: github.com/kaspanet/kaspad/domain/consensus/model/externalapi
BenchmarkCmp-16         61318008                20.1 ns/op             0 B/op          0 allocs/op
BenchmarkLess-16        294668134                4.07 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/kaspanet/kaspad/domain/consensus/model/externalapi   2.871s
```
