### PR TITLE
Increase log files sizes

### DIFF
--- a/infrastructure/logger/logger.go
+++ b/infrastructure/logger/logger.go
@@ -159,7 +159,8 @@ var subsystemLoggers = map[string]*Logger{
 
 // InitLog attaches log file and error log file to the backend log.
 func InitLog(logFile, errLogFile string) {
-	err := BackendLog.AddLogFileWithCustomRotator(logFile, LevelTrace, 100*1024, 4)
+	// 250 MB (MB=1000^2 bytes)
+	err := BackendLog.AddLogFileWithCustomRotator(logFile, LevelTrace, 1000*250, 32)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", logFile, LevelTrace, err)
 		os.Exit(1)


### PR DESCRIPTION
Increase the not compressed log file to 250MB(~235MiB). and keep the last 32 compressed logs.