### PR TITLE
Decrease grpc client dial timeout to one second

### DIFF
--- a/infrastructure/network/rpcclient/grpcclient/grpcclient.go
+++ b/infrastructure/network/rpcclient/grpcclient/grpcclient.go
@@ -24,7 +24,7 @@ type GRPCClient struct {
 
 // Connect connects to the RPC server with the given address
 func Connect(address string) (*GRPCClient, error) {
-	const dialTimeout = 30 * time.Second
+	const dialTimeout = 1 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 	defer cancel()
 


### PR DESCRIPTION
A dial timeout of 30 seconds is extremely high, so I reduced it to one second