### PR TITLE
Start IBDBlockLocator from PruningPoint instead of Genesis

### DIFF
--- a/app/protocol/flows/blockrelay/ibd.go
+++ b/app/protocol/flows/blockrelay/ibd.go
@@ -120,7 +120,10 @@ func (flow *handleRelayInvsFlow) syncHeaders(highHash *externalapi.DomainHash) e
 }
 
 func (flow *handleRelayInvsFlow) findHighestSharedBlockHash(targetHash *externalapi.DomainHash) (*externalapi.DomainHash, error) {
-	lowHash := flow.Config().ActiveNetParams.GenesisHash
+	lowHash, err := flow.Domain().Consensus().PruningPoint()
+	if err != nil {
+		return nil, err
+	}
 	highHash, err := flow.Domain().Consensus().GetHeadersSelectedTip()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR fixes #1375 by setting the lowHash of the IBDBlockLocator to the pruning point, rather then the genesis