### PR TITLE
Change log sizes and add some new features to logger

### DIFF
--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -171,6 +171,7 @@ func (pm *pruningManager) UpdatePruningPointByVirtual() error {
 	}
 
 	if !newCandidate.Equal(currentCandidate) {
+		log.Debugf("Staged a new pruning candidate, old: %s, new: %s", currentCandidate, newCandidate)
 		pm.pruningStore.StagePruningPointCandidate(newCandidate)
 	}
 
@@ -181,6 +182,7 @@ func (pm *pruningManager) UpdatePruningPointByVirtual() error {
 	}
 
 	if !newPruningPoint.Equal(currentPruningPoint) {
+		log.Debugf("Moving pruning point from %s to %s", currentPruningPoint, newPruningPoint)
 		err = pm.savePruningPoint(newPruningPoint)
 		if err != nil {
 			return err
@@ -446,6 +448,8 @@ func (pm *pruningManager) validateUTXOSetFitsCommitment(
 			"Calculated UTXOSet hash: %s. Commitment: %s",
 			pruningPointHash, utxoSetHash, expectedUTXOCommitment)
 	}
+
+	log.Debugf("Validated the pruning point %s UTXO commitment: %s", pruningPointHash, utxoSetHash)
 
 	return nil
 }

--- a/infrastructure/logger/logger.go
+++ b/infrastructure/logger/logger.go
@@ -160,7 +160,7 @@ var subsystemLoggers = map[string]*Logger{
 // InitLog attaches log file and error log file to the backend log.
 func InitLog(logFile, errLogFile string) {
 	// 280 MB (MB=1000^2 bytes)
-	err := BackendLog.AddLogFileWithCustomRotator(logFile, LevelTrace, 1000*280, 48)
+	err := BackendLog.AddLogFileWithCustomRotator(logFile, LevelTrace, 1000*280, 64)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", logFile, LevelTrace, err)
 		os.Exit(1)

--- a/infrastructure/logger/logger.go
+++ b/infrastructure/logger/logger.go
@@ -159,8 +159,8 @@ var subsystemLoggers = map[string]*Logger{
 
 // InitLog attaches log file and error log file to the backend log.
 func InitLog(logFile, errLogFile string) {
-	// 250 MB (MB=1000^2 bytes)
-	err := BackendLog.AddLogFileWithCustomRotator(logFile, LevelTrace, 1000*250, 32)
+	// 280 MB (MB=1000^2 bytes)
+	err := BackendLog.AddLogFileWithCustomRotator(logFile, LevelTrace, 1000*280, 48)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error adding log file %s as log rotator for level %s: %s", logFile, LevelTrace, err)
 		os.Exit(1)

--- a/infrastructure/logger/logs.go
+++ b/infrastructure/logger/logs.go
@@ -282,9 +282,11 @@ func (b *Backend) AddLogFile(logFile string, logLevel Level) error {
 // It'll create the file if it doesn't exist.
 func (b *Backend) AddLogFileWithCustomRotator(logFile string, logLevel Level, thresholdKB int64, maxRolls int) error {
 	logDir, _ := filepath.Split(logFile)
-	err := os.MkdirAll(logDir, 0700)
-	if err != nil {
-		return errors.Errorf("failed to create log directory: %s", err)
+	if logDir != "" {
+		err := os.MkdirAll(logDir, 0700)
+		if err != nil {
+			return errors.Errorf("failed to create log directory: %+v", err)
+		}
 	}
 	r, err := rotator.New(logFile, thresholdKB, false, maxRolls)
 	if err != nil {

--- a/infrastructure/logger/logs.go
+++ b/infrastructure/logger/logs.go
@@ -282,6 +282,7 @@ func (b *Backend) AddLogFile(logFile string, logLevel Level) error {
 // It'll create the file if it doesn't exist.
 func (b *Backend) AddLogFileWithCustomRotator(logFile string, logLevel Level, thresholdKB int64, maxRolls int) error {
 	logDir, _ := filepath.Split(logFile)
+	// if the logDir is empty then `logFile` is in the cwd and there's no need to create any directory.
 	if logDir != "" {
 		err := os.MkdirAll(logDir, 0700)
 		if err != nil {

--- a/infrastructure/logger/logs.go
+++ b/infrastructure/logger/logs.go
@@ -266,8 +266,8 @@ func callsite(flag uint32) (string, int) {
 }
 
 const (
-	defaultThresholdKB = 10 * 1024
-	defaultMaxRolls    = 3
+	defaultThresholdKB = 100 * 1000 // 100 MB logs by default.
+	defaultMaxRolls    = 8          // keep 8 last logs by default.
 )
 
 // AddLogFile adds a file which the log will write into on a certain


### PR DESCRIPTION
1. Increase the default log size to 100MB, and last 8 logs(after tar.gz it should be ~7MB each).
2. add an option to not write logs to stdout (by default it still does write to stdout).
3. allow logs in cwd.
4. Add more logs in pruning manager