### PR TITLE
Compare transaction IDs with Equal

### DIFF
--- a/app/protocol/flows/transactionrelay/handle_relayed_transactions.go
+++ b/app/protocol/flows/transactionrelay/handle_relayed_transactions.go
@@ -159,7 +159,7 @@ func (flow *handleRelayedTransactionsFlow) receiveTransactions(requestedTransact
 			return err
 		}
 		if msgTxNotFound != nil {
-			if msgTxNotFound.ID != expectedID {
+			if !msgTxNotFound.ID.Equal(expectedID) {
 				return protocolerrors.Errorf(true, "expected transaction %s, but got %s",
 					expectedID, msgTxNotFound.ID)
 			}


### PR DESCRIPTION
We accidentally used pointer comparison to compare transaction IDs. This is wrong, and we should compare by value