### PR TITLE
Fix target block rate

### DIFF
--- a/cmd/kaspaminer/mineloop.go
+++ b/cmd/kaspaminer/mineloop.go
@@ -64,6 +64,7 @@ func mineLoop(client *minerClient, numberOfBlocks uint64, targetBlocksPerSecond 
 						time.Sleep(deviation)
 					}
 					blockInWindowIndex = 0
+					windowExpectedEndTime = time.Now().Add(expectedDurationForWindow)
 				}
 			}
 


### PR DESCRIPTION
windowExpectedEndTime was not reset after each window, so the target block rate stopped to affect after the first window