### PR TITLE
Remove code coverage patch check and make it informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    patch: off
+
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
This should remove the annoying comments in PR review showing which exact lines aren't covered,
and also make the status check always pass.
we might want to remove this in the future when we can test flows.