### PR TITLE
Don't mark bad merkle root as invalid

### DIFF
--- a/domain/consensus/processes/blockprocessor/validateandinsertblock_test.go
+++ b/domain/consensus/processes/blockprocessor/validateandinsertblock_test.go
@@ -1,6 +1,8 @@
 package blockprocessor_test
 
 import (
+	"github.com/kaspanet/kaspad/domain/consensus/utils/constants"
+	"github.com/kaspanet/kaspad/domain/consensus/utils/merkle"
 	"strings"
 	"testing"
 
@@ -84,10 +86,11 @@ func TestBlockStatus(t *testing.T) {
 		if err != nil {
 			t.Fatalf("AddBlock: %+v", err)
 		}
+		invalidBlock.Transactions[0].Version = constants.MaxTransactionVersion + 1 // This should invalidate the block
 		invalidBlock.Header = blockheader.NewImmutableBlockHeader(
 			disqualifiedBlock.Header.Version(),
 			disqualifiedBlock.Header.ParentHashes(),
-			externalapi.NewDomainHashFromByteArray(&[externalapi.DomainHashSize]byte{}), // This should invalidate the block
+			merkle.CalculateHashMerkleRoot(invalidBlock.Transactions),
 			disqualifiedBlock.Header.AcceptedIDMerkleRoot(),
 			disqualifiedBlock.Header.UTXOCommitment(),
 			disqualifiedBlock.Header.TimeInMilliseconds(),

--- a/domain/consensus/processes/blockprocessor/validateblock.go
+++ b/domain/consensus/processes/blockprocessor/validateblock.go
@@ -55,8 +55,11 @@ func (bp *blockProcessor) validateBlock(block *externalapi.DomainBlock, isPrunin
 		if errors.As(err, &ruleerrors.RuleError{}) {
 			bp.discardAllChanges()
 			// If we got ErrMissingParents the block shouldn't be considered as invalid
-			// because it could be added later on when its parents are present.
-			if !errors.As(err, &ruleerrors.ErrMissingParents{}) {
+			// because it could be added later on when its parents are present, and if
+			// we get ErrBadMerkleRoot we shouldn't mark the block as invalid because
+			// later on we can get the block with transactions that fits the merkle
+			// root.
+			if !errors.As(err, &ruleerrors.ErrMissingParents{}) && !errors.Is(err, ruleerrors.ErrBadMerkleRoot) {
 				hash := consensushashing.BlockHash(block)
 				bp.blockStatusStore.Stage(hash, externalapi.StatusInvalid)
 				commitErr := bp.commitAllChanges()

--- a/domain/consensus/processes/blockprocessor/validateblock.go
+++ b/domain/consensus/processes/blockprocessor/validateblock.go
@@ -53,13 +53,14 @@ func (bp *blockProcessor) validateBlock(block *externalapi.DomainBlock, isPrunin
 	err = bp.validatePostProofOfWork(block, isPruningPoint)
 	if err != nil {
 		if errors.As(err, &ruleerrors.RuleError{}) {
-			bp.discardAllChanges()
 			// If we got ErrMissingParents the block shouldn't be considered as invalid
 			// because it could be added later on when its parents are present, and if
 			// we get ErrBadMerkleRoot we shouldn't mark the block as invalid because
 			// later on we can get the block with transactions that fits the merkle
 			// root.
 			if !errors.As(err, &ruleerrors.ErrMissingParents{}) && !errors.Is(err, ruleerrors.ErrBadMerkleRoot) {
+				// Discard all changes so we save only the block status
+				bp.discardAllChanges()
 				hash := consensushashing.BlockHash(block)
 				bp.blockStatusStore.Stage(hash, externalapi.StatusInvalid)
 				commitErr := bp.commitAllChanges()

--- a/domain/consensus/processes/blockvalidator/block_body_in_isolation.go
+++ b/domain/consensus/processes/blockvalidator/block_body_in_isolation.go
@@ -28,6 +28,11 @@ func (v *blockValidator) ValidateBodyInIsolation(blockHash *externalapi.DomainHa
 		return err
 	}
 
+	err = v.checkBlockHashMerkleRoot(block)
+	if err != nil {
+		return err
+	}
+
 	err = v.checkBlockSize(block)
 	if err != nil {
 		return err
@@ -59,11 +64,6 @@ func (v *blockValidator) ValidateBodyInIsolation(blockHash *externalapi.DomainHa
 	}
 
 	err = v.checkTransactionsInIsolation(block)
-	if err != nil {
-		return err
-	}
-
-	err = v.checkBlockHashMerkleRoot(block)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If we get ErrBadMerkleRoot we shouldn't mark the block as invalid because later on we can get the block with transactions that fits the merkle root.