### PR TITLE
Give different limit to the RPC server

### DIFF
--- a/infrastructure/network/netadapter/server/grpcserver/grpc_server.go
+++ b/infrastructure/network/netadapter/server/grpcserver/grpc_server.go
@@ -17,13 +17,11 @@ type gRPCServer struct {
 	server             *grpc.Server
 }
 
-// MaxMessageSize is the max size allowed for a message
-const MaxMessageSize = 10 * 1024 * 1024 // 10MB
-
 // newGRPCServer creates a gRPC server
-func newGRPCServer(listeningAddresses []string) *gRPCServer {
+func newGRPCServer(listeningAddresses []string, maxMessageSize int) *gRPCServer {
+	log.Debugf("Created new GRPC server with maxMessageSize %d", maxMessageSize)
 	return &gRPCServer{
-		server:             grpc.NewServer(grpc.MaxRecvMsgSize(MaxMessageSize), grpc.MaxSendMsgSize(MaxMessageSize)),
+		server:             grpc.NewServer(grpc.MaxRecvMsgSize(maxMessageSize), grpc.MaxSendMsgSize(maxMessageSize)),
 		listeningAddresses: listeningAddresses,
 	}
 }
@@ -39,8 +37,6 @@ func (s *gRPCServer) Start() error {
 			return err
 		}
 	}
-
-	log.Debugf("Server started with MaxMessageSize %d", MaxMessageSize)
 
 	return nil
 }

--- a/infrastructure/network/netadapter/server/grpcserver/p2pserver.go
+++ b/infrastructure/network/netadapter/server/grpcserver/p2pserver.go
@@ -18,9 +18,11 @@ type p2pServer struct {
 	gRPCServer
 }
 
+const p2pMaxMessageSize = 10 * 1024 * 1024 // 10MB
+
 // NewP2PServer creates a new P2PServer
 func NewP2PServer(listeningAddresses []string) (server.P2PServer, error) {
-	gRPCServer := newGRPCServer(listeningAddresses)
+	gRPCServer := newGRPCServer(listeningAddresses, p2pMaxMessageSize)
 	p2pServer := &p2pServer{gRPCServer: *gRPCServer}
 	protowire.RegisterP2PServer(gRPCServer.server, p2pServer)
 	return p2pServer, nil
@@ -48,7 +50,7 @@ func (p *p2pServer) Connect(address string) (server.Connection, error) {
 
 	client := protowire.NewP2PClient(gRPCClientConnection)
 	stream, err := client.MessageStream(context.Background(), grpc.UseCompressor(gzip.Name),
-		grpc.MaxCallRecvMsgSize(MaxMessageSize), grpc.MaxCallSendMsgSize(MaxMessageSize))
+		grpc.MaxCallRecvMsgSize(p2pMaxMessageSize), grpc.MaxCallSendMsgSize(p2pMaxMessageSize))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting client stream for %s", address)
 	}

--- a/infrastructure/network/netadapter/server/grpcserver/rpcserver.go
+++ b/infrastructure/network/netadapter/server/grpcserver/rpcserver.go
@@ -11,9 +11,12 @@ type rpcServer struct {
 	gRPCServer
 }
 
+// RPCMaxMessageSize is the max message size for the RPC server to send and receive
+const RPCMaxMessageSize = 1024 * 1024 * 1024 // 1 GB
+
 // NewRPCServer creates a new RPCServer
 func NewRPCServer(listeningAddresses []string) (server.Server, error) {
-	gRPCServer := newGRPCServer(listeningAddresses)
+	gRPCServer := newGRPCServer(listeningAddresses, RPCMaxMessageSize)
 	rpcServer := &rpcServer{gRPCServer: *gRPCServer}
 	protowire.RegisterRPCServer(gRPCServer.server, rpcServer)
 	return rpcServer, nil

--- a/infrastructure/network/rpcclient/grpcclient/grpcclient.go
+++ b/infrastructure/network/rpcclient/grpcclient/grpcclient.go
@@ -35,7 +35,7 @@ func Connect(address string) (*GRPCClient, error) {
 
 	grpcClient := protowire.NewRPCClient(gRPCConnection)
 	stream, err := grpcClient.MessageStream(context.Background(), grpc.UseCompressor(gzip.Name),
-		grpc.MaxCallRecvMsgSize(grpcserver.MaxMessageSize), grpc.MaxCallSendMsgSize(grpcserver.MaxMessageSize))
+		grpc.MaxCallRecvMsgSize(grpcserver.RPCMaxMessageSize), grpc.MaxCallSendMsgSize(grpcserver.RPCMaxMessageSize))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting client stream for %s", address)
 	}


### PR DESCRIPTION
Because GetUtxosByAddressesResponseMessage can be quite big, I increased the limit of RPC messages to 1GB.