### PR TITLE
fix missing UTXO notifications

### DIFF
--- a/app/rpc/rpccontext/notificationmanager.go
+++ b/app/rpc/rpccontext/notificationmanager.go
@@ -229,7 +229,7 @@ func (nl *NotificationListener) convertUTXOChangesToUTXOsChangedNotification(
 	for _, listenerAddress := range nl.propagateUTXOsChangedNotificationAddresses {
 		listenerScriptPublicKeyString := listenerAddress.ScriptPublicKeyString
 		if addedPairs, ok := utxoChanges.Added[listenerScriptPublicKeyString]; ok {
-			notification.Added = ConvertUTXOOutpointEntryPairsToUTXOsByAddressesEntries(listenerAddress.Address, addedPairs)
+			notification.Added = append(notification.Added, ConvertUTXOOutpointEntryPairsToUTXOsByAddressesEntries(listenerAddress.Address, addedPairs)...);
 		}
 		if removedOutpoints, ok := utxoChanges.Removed[listenerScriptPublicKeyString]; ok {
 			for outpoint := range removedOutpoints {


### PR DESCRIPTION
The following change fixes missing UTXO notifications, where otherwise, clients are notified only of the last UTXO in the notification set.