### PR TITLE
Remove accidental pointer indirection in dbKey

### DIFF
--- a/domain/consensus/database/key.go
+++ b/domain/consensus/database/key.go
@@ -9,6 +9,9 @@ func dbKeyToDatabaseKey(key model.DBKey) *database.Key {
 	if key, ok := key.(dbKey); ok {
 		return key.key
 	}
+	if key, ok := key.(*dbKey); ok {
+		return key.key
+	}
 	return dbBucketToDatabaseBucket(key.Bucket()).Key(key.Suffix())
 }
 
@@ -29,5 +32,5 @@ func (d dbKey) Suffix() []byte {
 }
 
 func newDBKey(key *database.Key) model.DBKey {
-	return &dbKey{key: key}
+	return dbKey{key: key}
 }


### PR DESCRIPTION
`dbKey` is a by-value type that holds a pointer in it. so using it also as a pointer doesn't help anything.
This worked because in Go pointer values also have the method set of their by-value receiver methods (but not the other way around), from the spec:
> The method set of the corresponding pointer type *T is the set of all methods declared with receiver *T or T (that is, it also contains the method set of T).

This should:
1. Remove a little pressure from the GC by removing an unnecessary pointer indirection.
2. Remove all the allocations that happened because the downcast didn't work.