### PR TITLE
When the pruning point moves, update its UTXO set outside of a database transaction

### DIFF
--- a/domain/consensus/datastructures/pruningstore/pruningstore.go
+++ b/domain/consensus/datastructures/pruningstore/pruningstore.go
@@ -106,7 +106,10 @@ func (ps *pruningStore) Commit(dbTx model.DBTransaction) error {
 	}
 
 	if ps.startSavingNewPruningPointUTXOSetStaging {
-		return dbTx.Put(savingNewPruningPointUTXOSetKey, []byte{0})
+		err := dbTx.Put(savingNewPruningPointUTXOSetKey, []byte{0})
+		if err != nil {
+			return err
+		}
 	}
 
 	ps.Discard()

--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -365,6 +365,10 @@ func (f *factory) NewConsensus(dagParams *dagconfig.Params, db infrastructuredat
 	if err != nil {
 		return nil, err
 	}
+	err = pruningManager.UpdatePruningPointUTXOSetIfRequired()
+	if err != nil {
+		return nil, err
+	}
 
 	return c, nil
 }

--- a/domain/consensus/model/interface_datastructures_pruningstore.go
+++ b/domain/consensus/model/interface_datastructures_pruningstore.go
@@ -12,6 +12,10 @@ type PruningStore interface {
 	HasPruningPointCandidate(dbContext DBReader) (bool, error)
 	PruningPoint(dbContext DBReader) (*externalapi.DomainHash, error)
 	HasPruningPoint(dbContext DBReader) (bool, error)
+
+	StageStartSavingNewPruningPointUTXOSet()
+	HadStartedSavingNewPruningPointUTXOSet(dbContext DBWriter) (bool, error)
+	FinishSavingNewPruningPointUTXOSet(dbContext DBWriter) error
 	UpdatePruningPointUTXOSet(dbContext DBWriter, utxoSetIterator ReadOnlyUTXOSetIterator) error
 
 	ClearImportedPruningPointUTXOs(dbContext DBWriter) error

--- a/domain/consensus/model/interface_datastructures_pruningstore.go
+++ b/domain/consensus/model/interface_datastructures_pruningstore.go
@@ -13,9 +13,9 @@ type PruningStore interface {
 	PruningPoint(dbContext DBReader) (*externalapi.DomainHash, error)
 	HasPruningPoint(dbContext DBReader) (bool, error)
 
-	StageStartSavingNewPruningPointUTXOSet()
-	HadStartedSavingNewPruningPointUTXOSet(dbContext DBWriter) (bool, error)
-	FinishSavingNewPruningPointUTXOSet(dbContext DBWriter) error
+	StageStartUpdatingPruningPointUTXOSet()
+	HadStartedUpdatingPruningPointUTXOSet(dbContext DBWriter) (bool, error)
+	FinishUpdatingPruningPointUTXOSet(dbContext DBWriter) error
 	UpdatePruningPointUTXOSet(dbContext DBWriter, utxoSetIterator ReadOnlyUTXOSetIterator) error
 
 	ClearImportedPruningPointUTXOs(dbContext DBWriter) error

--- a/domain/consensus/model/interface_datastructures_pruningstore.go
+++ b/domain/consensus/model/interface_datastructures_pruningstore.go
@@ -6,13 +6,14 @@ import "github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 type PruningStore interface {
 	Store
 	StagePruningPoint(pruningPointBlockHash *externalapi.DomainHash)
-	StagePruningPointUTXOSet(pruningPointUTXOSetIterator ReadOnlyUTXOSetIterator)
 	StagePruningPointCandidate(candidate *externalapi.DomainHash)
 	IsStaged() bool
 	PruningPointCandidate(dbContext DBReader) (*externalapi.DomainHash, error)
 	HasPruningPointCandidate(dbContext DBReader) (bool, error)
 	PruningPoint(dbContext DBReader) (*externalapi.DomainHash, error)
 	HasPruningPoint(dbContext DBReader) (bool, error)
+	UpdatePruningPointUTXOSet(dbContext DBWriter, utxoSetIterator ReadOnlyUTXOSetIterator) error
+
 	ClearImportedPruningPointUTXOs(dbContext DBWriter) error
 	AppendImportedPruningPointUTXOs(dbTx DBTransaction, outpointAndUTXOEntryPairs []*externalapi.OutpointAndUTXOEntryPair) error
 	ImportedPruningPointUTXOIterator(dbContext DBReader) (ReadOnlyUTXOSetIterator, error)

--- a/domain/consensus/model/interface_processes_pruningmanager.go
+++ b/domain/consensus/model/interface_processes_pruningmanager.go
@@ -8,4 +8,5 @@ type PruningManager interface {
 	IsValidPruningPoint(blockHash *externalapi.DomainHash) (bool, error)
 	ClearImportedPruningPointData() error
 	AppendImportedPruningPointUTXOs(outpointAndUTXOEntryPairs []*externalapi.OutpointAndUTXOEntryPair) error
+	UpdatePruningPointUTXOSetIfRequired() error
 }

--- a/domain/consensus/processes/blockprocessor/validateandinsertblock.go
+++ b/domain/consensus/processes/blockprocessor/validateandinsertblock.go
@@ -117,6 +117,11 @@ func (bp *blockProcessor) validateAndInsertBlock(block *externalapi.DomainBlock,
 		return nil, err
 	}
 
+	err = bp.pruningManager.UpdatePruningPointUTXOSetIfRequired()
+	if err != nil {
+		return nil, err
+	}
+
 	log.Debug(logger.NewLogClosure(func() string {
 		hashrate := difficulty.GetHashrateString(difficulty.CompactToBig(block.Header.Bits()), bp.targetTimePerBlock)
 		return fmt.Sprintf("Block %s validated and inserted, network hashrate: %s", blockHash, hashrate)

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kaspanet/kaspad/infrastructure/db/database"
 	"github.com/kaspanet/kaspad/infrastructure/logger"
 	"github.com/pkg/errors"
+	"runtime"
 )
 
 // pruningManager resolves and manages the current pruning point
@@ -521,6 +522,9 @@ func (pm *pruningManager) UpdatePruningPointUTXOSetIfRequired() error {
 func (pm *pruningManager) updatePruningPointUTXOSet() error {
 	onEnd := logger.LogAndMeasureExecutionTime(log, "updatePruningPointUTXOSet")
 	defer onEnd()
+
+	runtime.GC()
+	defer runtime.GC()
 
 	log.Debugf("Getting the pruning point")
 	pruningPoint, err := pm.pruningStore.PruningPoint(pm.databaseContext)

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -501,11 +501,11 @@ func (pm *pruningManager) AppendImportedPruningPointUTXOs(
 }
 
 func (pm *pruningManager) UpdatePruningPointUTXOSetIfRequired() error {
-	hadStartedSavingNewPruningPointUTXOSet, err := pm.pruningStore.HadStartedUpdatingPruningPointUTXOSet(pm.databaseContext)
+	hadStartedUpdatingPruningPointUTXOSet, err := pm.pruningStore.HadStartedUpdatingPruningPointUTXOSet(pm.databaseContext)
 	if err != nil {
 		return err
 	}
-	if !hadStartedSavingNewPruningPointUTXOSet {
+	if !hadStartedUpdatingPruningPointUTXOSet {
 		return nil
 	}
 

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -509,7 +509,13 @@ func (pm *pruningManager) UpdatePruningPointUTXOSetIfRequired() error {
 	}
 
 	log.Debugf("Pruning point UTXO set update is required")
-	return pm.updatePruningPointUTXOSet()
+	err = pm.updatePruningPointUTXOSet()
+	if err != nil {
+		return err
+	}
+	log.Debugf("Pruning point UTXO set updated")
+
+	return nil
 }
 
 func (pm *pruningManager) updatePruningPointUTXOSet() error {

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kaspanet/kaspad/infrastructure/db/database"
 	"github.com/kaspanet/kaspad/infrastructure/logger"
 	"github.com/pkg/errors"
-	"runtime"
 )
 
 // pruningManager resolves and manages the current pruning point
@@ -523,8 +522,8 @@ func (pm *pruningManager) updatePruningPointUTXOSet() error {
 	onEnd := logger.LogAndMeasureExecutionTime(log, "updatePruningPointUTXOSet")
 	defer onEnd()
 
-	runtime.GC()
-	defer runtime.GC()
+	logger.LogMemoryStats(log, "updatePruningPointUTXOSet start")
+	defer logger.LogMemoryStats(log, "updatePruningPointUTXOSet end")
 
 	log.Debugf("Getting the pruning point")
 	pruningPoint, err := pm.pruningStore.PruningPoint(pm.databaseContext)

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -319,7 +319,7 @@ func (pm *pruningManager) savePruningPoint(pruningPointHash *externalapi.DomainH
 	}
 
 	pm.pruningStore.StagePruningPoint(pruningPointHash)
-	pm.pruningStore.StageStartSavingNewPruningPointUTXOSet()
+	pm.pruningStore.StageStartUpdatingPruningPointUTXOSet()
 
 	return nil
 }
@@ -500,7 +500,7 @@ func (pm *pruningManager) AppendImportedPruningPointUTXOs(
 }
 
 func (pm *pruningManager) UpdatePruningPointUTXOSetIfRequired() error {
-	hadStartedSavingNewPruningPointUTXOSet, err := pm.pruningStore.HadStartedSavingNewPruningPointUTXOSet(pm.databaseContext)
+	hadStartedSavingNewPruningPointUTXOSet, err := pm.pruningStore.HadStartedUpdatingPruningPointUTXOSet(pm.databaseContext)
 	if err != nil {
 		return err
 	}
@@ -535,5 +535,5 @@ func (pm *pruningManager) updatePruningPointUTXOSet() error {
 	}
 
 	log.Debugf("Finishing updating the pruning point UTXO set")
-	return pm.pruningStore.FinishSavingNewPruningPointUTXOSet(pm.databaseContext)
+	return pm.pruningStore.FinishUpdatingPruningPointUTXOSet(pm.databaseContext)
 }

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -319,6 +319,7 @@ func (pm *pruningManager) savePruningPoint(pruningPointHash *externalapi.DomainH
 	}
 
 	pm.pruningStore.StagePruningPoint(pruningPointHash)
+	pm.pruningStore.StageStartSavingNewPruningPointUTXOSet()
 
 	return nil
 }

--- a/infrastructure/logger/utils.go
+++ b/infrastructure/logger/utils.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"runtime"
 	"time"
 )
@@ -19,8 +20,10 @@ func LogAndMeasureExecutionTime(log *Logger, functionName string) (onEnd func())
 
 // LogMemoryStats logs memory stats for `functionName`
 func LogMemoryStats(log *Logger, functionName string) {
-	stats := runtime.MemStats{}
-	runtime.ReadMemStats(&stats)
-	log.Debugf("%s: used memory: %d bytes, total: %d bytes", functionName,
-		stats.Alloc, stats.HeapIdle-stats.HeapReleased+stats.HeapInuse)
+	log.Debug(NewLogClosure(func() string {
+		stats := runtime.MemStats{}
+		runtime.ReadMemStats(&stats)
+		return fmt.Sprintf("%s: used memory: %d bytes, total: %d bytes", functionName,
+			stats.Alloc, stats.HeapIdle-stats.HeapReleased+stats.HeapInuse)
+	}))
 }

--- a/infrastructure/logger/utils.go
+++ b/infrastructure/logger/utils.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"runtime"
 	"time"
 )
 
@@ -14,4 +15,12 @@ func LogAndMeasureExecutionTime(log *Logger, functionName string) (onEnd func())
 	return func() {
 		log.Debugf("%s end. Took: %s", functionName, time.Since(start))
 	}
+}
+
+// LogMemoryStats logs memory stats for `functionName`
+func LogMemoryStats(log *Logger, functionName string) {
+	stats := runtime.MemStats{}
+	runtime.ReadMemStats(&stats)
+	log.Debugf("%s: used memory: %d bytes, total: %d bytes", functionName,
+		stats.Alloc, stats.HeapIdle-stats.HeapReleased+stats.HeapInuse)
 }


### PR DESCRIPTION
Currently, updating the pruning point's UTXO set takes an enormous amount of memory for batching along.
This PR implements a mechanism to alleviate that.