### PR TITLE
Add P2P/RPC name to the gRPC logs

### DIFF
--- a/infrastructure/network/netadapter/server/grpcserver/grpc_server.go
+++ b/infrastructure/network/netadapter/server/grpcserver/grpc_server.go
@@ -20,7 +20,7 @@ type gRPCServer struct {
 
 // newGRPCServer creates a gRPC server
 func newGRPCServer(listeningAddresses []string, maxMessageSize int, name string) *gRPCServer {
-	log.Debugf("Created new GRPC server with maxMessageSize %d", maxMessageSize)
+	log.Debugf("Created new %s GRPC server with maxMessageSize %d", name, maxMessageSize)
 	return &gRPCServer{
 		server:             grpc.NewServer(grpc.MaxRecvMsgSize(maxMessageSize), grpc.MaxSendMsgSize(maxMessageSize)),
 		listeningAddresses: listeningAddresses,
@@ -49,10 +49,10 @@ func (s *gRPCServer) listenOn(listenAddr string) error {
 		return errors.Wrapf(err, "%s error listening on %s", s.name, listenAddr)
 	}
 
-	spawn(s.name+" gRPCServer.listenOn-Serve", func() {
+	spawn(fmt.Sprintf("%s.gRPCServer.listenOn-Serve", s.name), func() {
 		err := s.server.Serve(listener)
 		if err != nil {
-			panics.Exit(log, fmt.Sprintf("error serving on %s: %+v", listenAddr, err))
+			panics.Exit(log, fmt.Sprintf("error serving %s on %s: %+v", s.name, listenAddr, err))
 		}
 	})
 

--- a/infrastructure/network/netadapter/server/grpcserver/p2pserver.go
+++ b/infrastructure/network/netadapter/server/grpcserver/p2pserver.go
@@ -22,7 +22,7 @@ const p2pMaxMessageSize = 10 * 1024 * 1024 // 10MB
 
 // NewP2PServer creates a new P2PServer
 func NewP2PServer(listeningAddresses []string) (server.P2PServer, error) {
-	gRPCServer := newGRPCServer(listeningAddresses, p2pMaxMessageSize)
+	gRPCServer := newGRPCServer(listeningAddresses, p2pMaxMessageSize, "P2P")
 	p2pServer := &p2pServer{gRPCServer: *gRPCServer}
 	protowire.RegisterP2PServer(gRPCServer.server, p2pServer)
 	return p2pServer, nil
@@ -37,7 +37,7 @@ func (p *p2pServer) MessageStream(stream protowire.P2P_MessageStreamServer) erro
 // Connect connects to the given address
 // This is part of the P2PServer interface
 func (p *p2pServer) Connect(address string) (server.Connection, error) {
-	log.Infof("Dialing to %s", address)
+	log.Infof("%s Dialing to %s", p.name, address)
 
 	const dialTimeout = 30 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
@@ -45,19 +45,19 @@ func (p *p2pServer) Connect(address string) (server.Connection, error) {
 
 	gRPCClientConnection, err := grpc.DialContext(ctx, address, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error connecting to %s", address)
+		return nil, errors.Wrapf(err, "%s error connecting to %s", p.name, address)
 	}
 
 	client := protowire.NewP2PClient(gRPCClientConnection)
 	stream, err := client.MessageStream(context.Background(), grpc.UseCompressor(gzip.Name),
 		grpc.MaxCallRecvMsgSize(p2pMaxMessageSize), grpc.MaxCallSendMsgSize(p2pMaxMessageSize))
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting client stream for %s", address)
+		return nil, errors.Wrapf(err, "%s error getting client stream for %s", p.name, address)
 	}
 
 	peerInfo, ok := peer.FromContext(stream.Context())
 	if !ok {
-		return nil, errors.Errorf("error getting stream peer info from context for %s", address)
+		return nil, errors.Errorf("%s error getting stream peer info from context for %s", p.name, address)
 	}
 	tcpAddress, ok := peerInfo.Addr.(*net.TCPAddr)
 	if !ok {
@@ -71,7 +71,7 @@ func (p *p2pServer) Connect(address string) (server.Connection, error) {
 		return nil, err
 	}
 
-	log.Infof("Connected to %s", address)
+	log.Infof("%s Connected to %s", p.name, address)
 
 	return connection, nil
 }

--- a/infrastructure/network/netadapter/server/grpcserver/rpcserver.go
+++ b/infrastructure/network/netadapter/server/grpcserver/rpcserver.go
@@ -16,7 +16,7 @@ const RPCMaxMessageSize = 1024 * 1024 * 1024 // 1 GB
 
 // NewRPCServer creates a new RPCServer
 func NewRPCServer(listeningAddresses []string) (server.Server, error) {
-	gRPCServer := newGRPCServer(listeningAddresses, RPCMaxMessageSize)
+	gRPCServer := newGRPCServer(listeningAddresses, RPCMaxMessageSize, "RPC")
 	rpcServer := &rpcServer{gRPCServer: *gRPCServer}
 	protowire.RegisterRPCServer(gRPCServer.server, rpcServer)
 	return rpcServer, nil


### PR DESCRIPTION
This should make it easier to figure out which port is p2p and which is rpc, and when an error occurs in which server did it happen