### PR TITLE
Remove default dns/grpc seeders

### DIFF
--- a/domain/dagconfig/params.go
+++ b/domain/dagconfig/params.go
@@ -204,7 +204,6 @@ var MainnetParams = Params{
 	Net:         appmessage.Mainnet,
 	RPCPort:     "16110",
 	DefaultPort: "16111",
-	DNSSeeds:    []string{"dnsseed.kas.pa"},
 
 	// DAG parameters
 	GenesisBlock:                   &genesisBlock,
@@ -261,7 +260,6 @@ var TestnetParams = Params{
 	Net:         appmessage.Testnet,
 	RPCPort:     "16210",
 	DefaultPort: "16211",
-	GRPCSeeds:   []string{"testnet-dnsseed.kas.pa:17100"},
 
 	// DAG parameters
 	GenesisBlock:                   &testnetGenesisBlock,


### PR DESCRIPTION
Currently we have ad hoc seeders, and the more testnet will grow the more seeders we'll have, it doesn't make sense for us to need to release a new version for any change in the seeders, so they'll have to be passed in through the CLI for now.