### PR TITLE
Add block type to MineJSON

### DIFF
--- a/domain/consensus/model/testapi/test_consensus.go
+++ b/domain/consensus/model/testapi/test_consensus.go
@@ -8,6 +8,20 @@ import (
 	"io"
 )
 
+// MineJSONBlockType indicates which type of blocks MineJSON mines
+type MineJSONBlockType int
+
+const (
+	// MineJSONBlockTypeUTXOValidBlock indicates for MineJSON to mine valid blocks.
+	MineJSONBlockTypeUTXOValidBlock MineJSONBlockType = iota
+
+	// MineJSONBlockTypeUTXOInvalidBlock indicates for MineJSON to mine UTXO invalid blocks.
+	MineJSONBlockTypeUTXOInvalidBlock
+
+	// MineJSONBlockTypeUTXOInvalidHeader indicates for MineJSON to mine UTXO invalid headers.
+	MineJSONBlockTypeUTXOInvalidHeader
+)
+
 // TestConsensus wraps the Consensus interface with some methods that are needed by tests only
 type TestConsensus interface {
 	externalapi.Consensus
@@ -33,7 +47,7 @@ type TestConsensus interface {
 	AddUTXOInvalidBlock(parentHashes []*externalapi.DomainHash) (*externalapi.DomainHash,
 		*externalapi.BlockInsertionResult, error)
 
-	MineJSON(r io.Reader) (tips []*externalapi.DomainHash, err error)
+	MineJSON(r io.Reader, blockType MineJSONBlockType) (tips []*externalapi.DomainHash, err error)
 	DiscardAllStores()
 
 	AcceptanceDataStore() model.AcceptanceDataStore

--- a/domain/consensus/processes/reachabilitymanager/reachability_stretch_test.go
+++ b/domain/consensus/processes/reachabilitymanager/reachability_stretch_test.go
@@ -54,7 +54,7 @@ func buildJsonDAG(t *testing.T, tc testapi.TestConsensus, attackJson bool) (tips
 	}
 	defer gzipReader.Close()
 
-	tips, err = tc.MineJSON(gzipReader)
+	tips, err = tc.MineJSON(gzipReader, testapi.MineJSONBlockTypeUTXOInvalidHeader)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I added an option to mine different types of blocks using MineJSON: UTXO valid blocks, UTXO invalid blocks, and UTXO invalid headers