### PR TITLE
Prevent infinite ticker leaks in kaspaminer

### DIFF
--- a/cmd/kaspaminer/mineloop.go
+++ b/cmd/kaspaminer/mineloop.go
@@ -167,6 +167,8 @@ func templatesLoop(client *minerClient, miningAddr util.Address,
 		newTemplateChan <- template
 	}
 	getBlockTemplate()
+	const tickerTime = 500 * time.Millisecond
+	ticker := time.NewTicker(tickerTime)
 	for {
 		select {
 		case <-stopChan:
@@ -174,7 +176,8 @@ func templatesLoop(client *minerClient, miningAddr util.Address,
 			return
 		case <-client.blockAddedNotificationChan:
 			getBlockTemplate()
-		case <-time.Tick(500 * time.Millisecond):
+			ticker.Reset(tickerTime)
+		case <-ticker.C:
 			getBlockTemplate()
 		}
 	}

--- a/infrastructure/network/connmanager/connmanager.go
+++ b/infrastructure/network/connmanager/connmanager.go
@@ -147,8 +147,7 @@ func (c *ConnectionManager) IsBanned(netConnection *netadapter.NetConnection) (b
 func (c *ConnectionManager) waitTillNextIteration() {
 	select {
 	case <-c.resetLoopChan:
-		c.loopTicker.Stop()
-		c.loopTicker = time.NewTicker(connectionsLoopInterval)
+		c.loopTicker.Reset(connectionsLoopInterval)
 	case <-c.loopTicker.C:
 	}
 }


### PR DESCRIPTION
>  Tick is a convenience wrapper for NewTicker providing access to the ticking channel only. While Tick is useful for clients that have no need to shut down the Ticker, be aware that without a way to shut it down the underlying Ticker cannot be recovered by the garbage collector; it "leaks". Unlike NewTicker, Tick will return nil if d <= 0. 

https://golang.org/pkg/time/#Tick