### PR TITLE
Add dummy go files for test only package, to mitigate golang/go#27333

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,8 +63,7 @@ jobs:
           go-version: 1.15
 
       - name: Create coverage file
-        # Because of https://github.com/golang/go/issues/27333 this seem to "fail" even though nothing is wrong, so ignore the failure
-        run: go test -json -covermode=atomic -coverpkg=./... -coverprofile coverage.txt ./... || true
+        run: go test -json -covermode=atomic -coverpkg=./... -coverprofile coverage.txt ./...
 
       - name: Upload coverage file
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,7 @@ jobs:
           go-version: 1.15
 
       - name: Create coverage file
-        run: go test -json -covermode=atomic -coverpkg=./... -coverprofile coverage.txt ./...
+        run: go test -covermode=atomic -coverpkg=./... -coverprofile coverage.txt ./...
 
       - name: Upload coverage file
         run: bash <(curl -s https://codecov.io/bash)

--- a/app/protocol/flows/testing/testing.go
+++ b/app/protocol/flows/testing/testing.go
@@ -1,0 +1,1 @@
+package testing

--- a/app/protocol/flows/testing/testing.go
+++ b/app/protocol/flows/testing/testing.go
@@ -1,1 +1,4 @@
 package testing
+
+// Because of a bug in Go coverage fails if you have packages with test files only. See https://github.com/golang/go/issues/27333
+// So this is a dummy non-test go file in the package.

--- a/testing/integration/integration.go
+++ b/testing/integration/integration.go
@@ -1,0 +1,1 @@
+package integration

--- a/testing/integration/integration.go
+++ b/testing/integration/integration.go
@@ -1,1 +1,4 @@
 package integration
+
+// Because of a bug in Go coverage fails if you have packages with test files only. See https://github.com/golang/go/issues/27333
+// So this is a dummy non-test go file in the package.


### PR DESCRIPTION
Because of https://github.com/golang/go/issues/27333 our coverage file is currently empty and failing, to mitigate this we just need a non-test go file in testing only packages