### PR TITLE
Move testGHOSTDagSorter to testutils, and build a boilerplate for overriding specific managers

### DIFF
--- a/domain/consensus/constructors.go
+++ b/domain/consensus/constructors.go
@@ -1,0 +1,6 @@
+package consensus
+
+import "github.com/kaspanet/kaspad/domain/consensus/model"
+
+// GHOSTDAGManagerConstructor is the function signature for a constructor of a type implementing model.GHOSTDAGManager
+type GHOSTDAGManagerConstructor func(model.DBReader, model.DAGTopologyManager, model.GHOSTDAGDataStore, model.BlockHeaderStore, model.KType) model.GHOSTDAGManager

--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -51,15 +51,21 @@ type Factory interface {
 		externalapi.Consensus, error)
 	NewTestConsensus(dagParams *dagconfig.Params, isArchivalNode bool, testName string) (
 		tc testapi.TestConsensus, teardown func(keepDataDir bool), err error)
-	NewTestConsensusWithDataDir(dagParams *dagconfig.Params, dataDir string, isArchivalNode bool) (
-		tc testapi.TestConsensus, teardown func(keepDataDir bool), err error)
+
+	SetDataDir(dataDir string)
+	SetGHOSTDAGManager(ghostdagConstructor GHOSTDAGManagerConstructor)
 }
 
-type factory struct{}
+type factory struct {
+	dataDir             string
+	ghostdagConstructor GHOSTDAGManagerConstructor
+}
 
 // NewFactory creates a new Consensus factory
 func NewFactory() Factory {
-	return &factory{}
+	return &factory{
+		ghostdagConstructor: ghostdagmanager.New,
+	}
 }
 
 // NewConsensus instantiates a new Consensus
@@ -107,7 +113,7 @@ func (f *factory) NewConsensus(dagParams *dagconfig.Params, db infrastructuredat
 		reachabilityManager,
 		blockRelationStore,
 		ghostdagDataStore)
-	ghostdagManager := ghostdagmanager.New(
+	ghostdagManager := f.ghostdagConstructor(
 		dbManager,
 		dagTopologyManager,
 		ghostdagDataStore,
@@ -380,19 +386,14 @@ func (f *factory) NewConsensus(dagParams *dagconfig.Params, db infrastructuredat
 
 func (f *factory) NewTestConsensus(dagParams *dagconfig.Params, isArchivalNode bool, testName string) (
 	tc testapi.TestConsensus, teardown func(keepDataDir bool), err error) {
-
-	dataDir, err := ioutil.TempDir("", testName)
-	if err != nil {
-		return nil, nil, err
+	datadir := f.dataDir
+	if datadir == "" {
+		datadir, err = ioutil.TempDir("", testName)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
-
-	return f.NewTestConsensusWithDataDir(dagParams, dataDir, isArchivalNode)
-}
-
-func (f *factory) NewTestConsensusWithDataDir(dagParams *dagconfig.Params, dataDir string, isArchivalNode bool) (
-	tc testapi.TestConsensus, teardown func(keepDataDir bool), err error) {
-
-	db, err := ldb.NewLevelDB(dataDir)
+	db, err := ldb.NewLevelDB(datadir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -402,9 +403,7 @@ func (f *factory) NewTestConsensusWithDataDir(dagParams *dagconfig.Params, dataD
 	}
 
 	consensusAsImplementation := consensusAsInterface.(*consensus)
-
 	testConsensusStateManager := consensusstatemanager.NewTestConsensusStateManager(consensusAsImplementation.consensusStateManager)
-
 	testTransactionValidator := transactionvalidator.NewTestTransactionValidator(consensusAsImplementation.transactionValidator)
 
 	tstConsensus := &testConsensus{
@@ -420,12 +419,19 @@ func (f *factory) NewTestConsensusWithDataDir(dagParams *dagconfig.Params, dataD
 	teardown = func(keepDataDir bool) {
 		db.Close()
 		if !keepDataDir {
-			err := os.RemoveAll(dataDir)
+			err := os.RemoveAll(f.dataDir)
 			if err != nil {
 				log.Errorf("Error removing data directory for test consensus: %s", err)
 			}
 		}
 	}
-
 	return tstConsensus, teardown, nil
+}
+
+func (f *factory) SetDataDir(dataDir string) {
+	f.dataDir = dataDir
+}
+
+func (f *factory) SetGHOSTDAGManager(ghostdagConstructor GHOSTDAGManagerConstructor) {
+	f.ghostdagConstructor = ghostdagConstructor
 }

--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -52,8 +52,8 @@ type Factory interface {
 	NewTestConsensus(dagParams *dagconfig.Params, isArchivalNode bool, testName string) (
 		tc testapi.TestConsensus, teardown func(keepDataDir bool), err error)
 
-	SetDataDir(dataDir string)
-	SetGHOSTDAGManager(ghostdagConstructor GHOSTDAGManagerConstructor)
+	SetTestDataDir(dataDir string)
+	SetTestGHOSTDAGManager(ghostdagConstructor GHOSTDAGManagerConstructor)
 }
 
 type factory struct {
@@ -428,10 +428,10 @@ func (f *factory) NewTestConsensus(dagParams *dagconfig.Params, isArchivalNode b
 	return tstConsensus, teardown, nil
 }
 
-func (f *factory) SetDataDir(dataDir string) {
+func (f *factory) SetTestDataDir(dataDir string) {
 	f.dataDir = dataDir
 }
 
-func (f *factory) SetGHOSTDAGManager(ghostdagConstructor GHOSTDAGManagerConstructor) {
+func (f *factory) SetTestGHOSTDAGManager(ghostdagConstructor GHOSTDAGManagerConstructor) {
 	f.ghostdagConstructor = ghostdagConstructor
 }

--- a/domain/consensus/processes/consensusstatemanager/virtual_parents_test.go
+++ b/domain/consensus/processes/consensusstatemanager/virtual_parents_test.go
@@ -32,8 +32,8 @@ func TestConsensusStateManager_pickVirtualParents(t *testing.T) {
 				t.Fatalf("Consensus failed building a block: %v", err)
 			}
 			blockParents := block.Header.ParentHashes()
-			sort.Sort(consensus.NewTestGhostDAGSorter(virtualRelations.Parents, tc, t))
-			sort.Sort(consensus.NewTestGhostDAGSorter(blockParents, tc, t))
+			sort.Sort(testutils.NewTestGhostDAGSorter(virtualRelations.Parents, tc, t))
+			sort.Sort(testutils.NewTestGhostDAGSorter(blockParents, tc, t))
 			if !externalapi.HashesEqual(virtualRelations.Parents, blockParents) {
 				t.Fatalf("Block relations and BuildBlock return different parents for virtual, %s != %s", virtualRelations.Parents, blockParents)
 			}
@@ -54,7 +54,7 @@ func TestConsensusStateManager_pickVirtualParents(t *testing.T) {
 		}
 
 		virtualParents := getSortedVirtualParents(tc)
-		sort.Sort(consensus.NewTestGhostDAGSorter(parents, tc, t))
+		sort.Sort(testutils.NewTestGhostDAGSorter(parents, tc, t))
 
 		// Make sure the first half of the blocks are with highest blueWork
 		// we use (max+1)/2 because the first "half" is rounded up, so `(dividend + (divisor - 1)) / divisor` = `(max + (2-1))/2` = `(max+1)/2`
@@ -102,7 +102,7 @@ func TestConsensusStateManager_pickVirtualParents(t *testing.T) {
 			parents = append(parents, block)
 		}
 
-		sort.Sort(consensus.NewTestGhostDAGSorter(parents, tc, t))
+		sort.Sort(testutils.NewTestGhostDAGSorter(parents, tc, t))
 		virtualParents = getSortedVirtualParents(tc)
 		if !externalapi.HashesEqual(virtualParents, parents) {
 			t.Fatalf("Expected VirtualParents and parents to be equal, instead: %s != %s", virtualParents, parents)

--- a/domain/consensus/processes/dagtraversalmanager/window_test.go
+++ b/domain/consensus/processes/dagtraversalmanager/window_test.go
@@ -344,7 +344,7 @@ func TestBlueBlockWindow(t *testing.T) {
 			if err != nil {
 				t.Fatalf("BlueWindow: %s", err)
 			}
-			sort.Sort(consensus.NewTestGhostDAGSorter(window, tc, t))
+			sort.Sort(testutils.NewTestGhostDAGSorter(window, tc, t))
 			if err := checkWindowIDs(window, blockData.expectedWindowWithGenesisPadding, idByBlockMap); err != nil {
 				t.Errorf("Unexpected values for window for block %s: %s", blockData.id, err)
 			}

--- a/domain/consensus/utils/testutils/test_ghostdag.go
+++ b/domain/consensus/utils/testutils/test_ghostdag.go
@@ -1,4 +1,4 @@
-package consensus
+package testutils
 
 import (
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"


### PR DESCRIPTION
Every once in a while I find myself wanting to override a manager/store, but I never saw a good way to do it. 
I believe using the Factory in a builder pattern matter and providing constructors is a good way to do this, so even though I don't use it in this PR I decided it's worth to have the skeleton and a sample(ghostdag manager) so that in the future we can extend on that.

I also used the same pattern for the datadir, decreasing the amount of boilerplate.
