### PR TITLE
Don't fsync immediately after all writes

### DIFF
--- a/infrastructure/db/database/ldb/options.go
+++ b/infrastructure/db/database/ldb/options.go
@@ -8,6 +8,7 @@ var (
 		BlockCacheCapacity:     256 * opt.MiB,
 		WriteBuffer:            128 * opt.MiB,
 		DisableSeeksCompaction: true,
+		NoSync:                 true,
 	}
 
 	// Options is a function that returns a leveldb

--- a/infrastructure/db/database/ldb/transaction.go
+++ b/infrastructure/db/database/ldb/transaction.go
@@ -4,7 +4,6 @@ import (
 	"github.com/kaspanet/kaspad/infrastructure/db/database"
 	"github.com/pkg/errors"
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
 // LevelDBTransaction is a thin wrapper around native leveldb
@@ -41,7 +40,7 @@ func (tx *LevelDBTransaction) Commit() error {
 	}
 
 	tx.isClosed = true
-	return errors.WithStack(tx.db.ldb.Write(tx.batch, &opt.WriteOptions{Sync: true}))
+	return errors.WithStack(tx.db.ldb.Write(tx.batch, nil))
 }
 
 // Rollback rolls back whatever changes were made to the


### PR DESCRIPTION
This greatly improves database write performance at the cost of relatively negligible data loss.