### PR TITLE
Don't ban when sending pruned blocks

### DIFF
--- a/app/protocol/flows/blockrelay/handle_relay_invs.go
+++ b/app/protocol/flows/blockrelay/handle_relay_invs.go
@@ -107,6 +107,11 @@ func (flow *handleRelayInvsFlow) start() error {
 		log.Debugf("Processing block %s", inv.Hash)
 		missingParents, blockInsertionResult, err := flow.processBlock(block)
 		if err != nil {
+			if errors.Is(err, ruleerrors.ErrPrunedBlock) {
+				log.Infof("Ignoring pruned block %s", inv.Hash)
+				continue
+			}
+
 			if errors.Is(err, ruleerrors.ErrDuplicateBlock) {
 				log.Infof("Ignoring duplicate block %s", inv.Hash)
 				continue


### PR DESCRIPTION
On handshake an out of date node sends its selected tip, which can be below the pruning point. We don't want to ban such behaviour.