### PR TITLE
Fix a data race in the block logger in tests

### DIFF
--- a/domain/consensus/processes/blockprocessor/blockprocessor.go
+++ b/domain/consensus/processes/blockprocessor/blockprocessor.go
@@ -3,6 +3,7 @@ package blockprocessor
 import (
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"github.com/kaspanet/kaspad/domain/consensus/processes/blockprocessor/blocklogger"
 	"github.com/kaspanet/kaspad/infrastructure/logger"
 	"time"
 )
@@ -13,6 +14,7 @@ type blockProcessor struct {
 	genesisHash        *externalapi.DomainHash
 	targetTimePerBlock time.Duration
 	databaseContext    model.DBManager
+	blockLogger        *blocklogger.BlockLogger
 
 	consensusStateManager model.ConsensusStateManager
 	pruningManager        model.PruningManager
@@ -49,6 +51,7 @@ func New(
 	genesisHash *externalapi.DomainHash,
 	targetTimePerBlock time.Duration,
 	databaseContext model.DBManager,
+
 	consensusStateManager model.ConsensusStateManager,
 	pruningManager model.PruningManager,
 	blockValidator model.BlockValidator,
@@ -81,6 +84,7 @@ func New(
 		genesisHash:           genesisHash,
 		targetTimePerBlock:    targetTimePerBlock,
 		databaseContext:       databaseContext,
+		blockLogger:           blocklogger.NewBlockLogger(),
 		pruningManager:        pruningManager,
 		blockValidator:        blockValidator,
 		dagTopologyManager:    dagTopologyManager,

--- a/domain/consensus/processes/blockprocessor/validateandinsertblock.go
+++ b/domain/consensus/processes/blockprocessor/validateandinsertblock.go
@@ -2,7 +2,6 @@ package blockprocessor
 
 import (
 	"fmt"
-	"github.com/kaspanet/kaspad/domain/consensus/processes/blockprocessor/blocklogger"
 	"github.com/kaspanet/kaspad/util/difficulty"
 
 	"github.com/kaspanet/kaspad/domain/consensus/model"
@@ -144,7 +143,7 @@ func (bp *blockProcessor) validateAndInsertBlock(block *externalapi.DomainBlock,
 		return nil, logClosureErr
 	}
 
-	blocklogger.LogBlock(block)
+	bp.blockLogger.LogBlock(block)
 
 	return &externalapi.BlockInsertionResult{
 		VirtualSelectedParentChainChanges: selectedParentChainChanges,


### PR DESCRIPTION
The globals assumed that consensus is single threaded, but in tests we can have multiple instances of Consensus running in multiple goroutines