### PR TITLE
Nightly run for go test race detector

### DIFF
--- a/.github/workflows/go-race.yml
+++ b/.github/workflows/go-race.yml
@@ -1,0 +1,48 @@
+name: Go-Race
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  race_test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        branch: [ master, latest ]
+    name: Race detection on ${{ matrix.branch }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Set scheduled branch name
+        shell: bash
+        if: github.event_name == 'schedule'
+        run: |
+          if [ "${{ matrix.branch }}" == "master" ]; then
+            echo "run_on=master" >> $GITHUB_ENV
+          fi
+          if [ "${{ matrix.branch }}" == "latest" ]; then
+            branch=$(git branch -r | grep 'v\([0-9]\+\.\)\([0-9]\+\.\)\([0-9]\+\)-dev' | sort -Vr | head -1 | xargs)
+            echo "run_on=${branch}" >> $GITHUB_ENV
+          fi
+
+      - name: Set manual branch name
+        shell: bash
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "run_on=${{ github.ref }}" >> $GITHUB_ENV
+
+      - name: Test with race detector
+        shell: bash
+        run: |
+          git checkout "${{ env.run_on }}"
+          git status
+          go test -race ./...


### PR DESCRIPTION
This will run every night at 00:00 UTC `go test -race ./...` on the latest version branch + on master.
we can also trigger it manually in `Actions` and choose which branch we want it to run on.

Example of manually choosing: https://github.com/elichai/kaspad/runs/1912918114

(note that even when manually choosing the branch it will show it as master+latest, but both will just run on that branch )