### PR TITLE
Make antiPastHashesBetween return blocks sorted in ghostdag-order

### DIFF
--- a/app/rpc/rpchandlers/get_blocks_test.go
+++ b/app/rpc/rpchandlers/get_blocks_test.go
@@ -130,12 +130,6 @@ func TestHandleGetBlocks(t *testing.T) {
 				virtualSelectedParent, actualBlocks.BlockHashes)
 		}
 
-		// TODO: Remove this
-		err = tc.RenderDAGToDot("/tmp/blabla.svg")
-		if err != nil {
-			panic(err)
-		}
-
 		expectedOrder = append([]*externalapi.DomainHash{params.GenesisHash}, expectedOrder...)
 		actualOrder := getBlocks(nil)
 		if !reflect.DeepEqual(actualOrder.BlockHashes, hashes.ToStrings(expectedOrder)) {

--- a/domain/consensus/log.go
+++ b/domain/consensus/log.go
@@ -2,6 +2,8 @@ package consensus
 
 import (
 	"github.com/kaspanet/kaspad/infrastructure/logger"
+	"github.com/kaspanet/kaspad/util/panics"
 )
 
 var log, _ = logger.Get(logger.SubsystemTags.BDAG)
+var spawn = panics.GoroutineWrapperFunc(log)

--- a/domain/consensus/model/testapi/test_consensus.go
+++ b/domain/consensus/model/testapi/test_consensus.go
@@ -1,11 +1,12 @@
 package testapi
 
 import (
+	"io"
+
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/dagconfig"
 	"github.com/kaspanet/kaspad/infrastructure/db/database"
-	"io"
 )
 
 // MineJSONBlockType indicates which type of blocks MineJSON mines
@@ -49,6 +50,8 @@ type TestConsensus interface {
 
 	MineJSON(r io.Reader, blockType MineJSONBlockType) (tips []*externalapi.DomainHash, err error)
 	DiscardAllStores()
+
+	RenderDAGToDot(filename string) error
 
 	AcceptanceDataStore() model.AcceptanceDataStore
 	BlockHeaderStore() model.BlockHeaderStore

--- a/domain/consensus/processes/syncmanager/antipast.go
+++ b/domain/consensus/processes/syncmanager/antipast.go
@@ -137,7 +137,7 @@ func (sm *syncManager) findHighHashAccordingToMaxBlueScoreDifference(lowHash *ex
 	highHash *externalapi.DomainHash, maxBlueScoreDifference uint64, highBlockGHOSTDAGData *model.BlockGHOSTDAGData,
 	lowBlockGHOSTDAGData *model.BlockGHOSTDAGData) (*externalapi.DomainHash, error) {
 
-	if highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore()+1 > maxBlueScoreDifference {
+	if highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore() <= maxBlueScoreDifference {
 		return highHash, nil
 	}
 
@@ -146,17 +146,18 @@ func (sm *syncManager) findHighHashAccordingToMaxBlueScoreDifference(lowHash *ex
 		return nil, err
 	}
 	for ok := iterator.First(); ok; ok = iterator.Next() {
-		highHash, err = iterator.Get()
+		highHashCandidate, err := iterator.Get()
 		if err != nil {
 			return nil, err
 		}
-		highBlockGHOSTDAGData, err = sm.ghostdagDataStore.Get(sm.databaseContext, highHash)
+		highBlockGHOSTDAGData, err = sm.ghostdagDataStore.Get(sm.databaseContext, highHashCandidate)
 		if err != nil {
 			return nil, err
 		}
-		if highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore()+1 > maxBlueScoreDifference {
+		if highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore() > maxBlueScoreDifference {
 			break
 		}
+		highHash = highHashCandidate
 	}
 	return highHash, nil
 }

--- a/domain/consensus/processes/syncmanager/antipast.go
+++ b/domain/consensus/processes/syncmanager/antipast.go
@@ -89,7 +89,7 @@ func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.Doma
 	}
 
 	// The process above doesn't return highHash, so include it explicitly, unless highHash == lowHash
-	if lowHash != highHash {
+	if !lowHash.Equal(highHash) {
 		blockHashes = append(blockHashes, highHash)
 	}
 

--- a/domain/consensus/processes/syncmanager/antipast.go
+++ b/domain/consensus/processes/syncmanager/antipast.go
@@ -9,6 +9,7 @@ import (
 // antiPastHashesBetween returns the hashes of the blocks between the
 // lowHash's antiPast and highHash's antiPast, or up to
 // `maxBlueScoreDifference`, if non-zero.
+// The result excludes lowHash and includes highHash. If lowHash == highHash, returns nothing.
 func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.DomainHash,
 	maxBlueScoreDifference uint64) ([]*externalapi.DomainHash, error) {
 
@@ -86,6 +87,12 @@ func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.Doma
 			blockHashes = append(blockHashes, blockHash)
 		}
 	}
+
+	// The process above doesn't return highHash, so include it explicitly, unless highHash == lowHash
+	if lowHash != highHash {
+		blockHashes = append(blockHashes, highHash)
+	}
+
 	return blockHashes, nil
 }
 
@@ -117,6 +124,7 @@ func (sm *syncManager) getSortedMergeSet(current *externalapi.DomainHash) ([]*ex
 			i++
 		} else {
 			sortedMergeSet = append(sortedMergeSet, currentRed)
+			j++
 		}
 	}
 	sortedMergeSet = append(sortedMergeSet, blueMergeSet[i:]...)

--- a/domain/consensus/processes/syncmanager/antipast.go
+++ b/domain/consensus/processes/syncmanager/antipast.go
@@ -137,6 +137,10 @@ func (sm *syncManager) findHighHashAccordingToMaxBlueScoreDifference(lowHash *ex
 	highHash *externalapi.DomainHash, maxBlueScoreDifference uint64, highBlockGHOSTDAGData *model.BlockGHOSTDAGData,
 	lowBlockGHOSTDAGData *model.BlockGHOSTDAGData) (*externalapi.DomainHash, error) {
 
+	if highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore()+1 > maxBlueScoreDifference {
+		return highHash, nil
+	}
+
 	iterator, err := sm.dagTraversalManager.SelectedChildIterator(highHash, lowHash)
 	if err != nil {
 		return nil, err

--- a/domain/consensus/processes/syncmanager/antipast.go
+++ b/domain/consensus/processes/syncmanager/antipast.go
@@ -18,9 +18,6 @@ func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.Doma
 	// We keep originalLowHash to filter out blocks in it's past later down the road
 	originalLowHash := lowHash
 	var err error
-	if !lowHash.Equal(highHash) {
-		log.Criticalf("REMOVE MEEEEE!!!!!")
-	}
 	lowHash, err = sm.findLowHashInHighHashSelectedParentChain(lowHash, highHash)
 	if err != nil {
 		return nil, err
@@ -79,7 +76,7 @@ func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.Doma
 
 		// append to blockHashes all blocks in sortedMergeSet which are not in the past of originalLowHash
 		for _, blockHash := range sortedMergeSet {
-			isInPastOfOriginalLowHash, err := sm.dagTopologyManager.IsAncestorOf(originalLowHash, blockHash)
+			isInPastOfOriginalLowHash, err := sm.dagTopologyManager.IsAncestorOf(blockHash, originalLowHash)
 			if err != nil {
 				return nil, err
 			}
@@ -100,8 +97,8 @@ func (sm *syncManager) getSortedMergeSet(current *externalapi.DomainHash) ([]*ex
 
 	blueMergeSet := currentGhostdagData.MergeSetBlues()
 	redMergeSet := currentGhostdagData.MergeSetReds()
+	sortedMergeSet := make([]*externalapi.DomainHash, 0, len(blueMergeSet)+len(redMergeSet))
 	selectedParent, blueMergeSet := blueMergeSet[0], blueMergeSet[1:]
-	sortedMergeSet := make([]*externalapi.DomainHash, len(blueMergeSet)+len(redMergeSet))
 	sortedMergeSet = append(sortedMergeSet, selectedParent)
 	i, j := 0, 0
 	for i < len(blueMergeSet) && j < len(redMergeSet) {

--- a/domain/consensus/processes/syncmanager/antipast.go
+++ b/domain/consensus/processes/syncmanager/antipast.go
@@ -18,6 +18,9 @@ func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.Doma
 	// We keep originalLowHash to filter out blocks in it's past later down the road
 	originalLowHash := lowHash
 	var err error
+	if !lowHash.Equal(highHash) {
+		log.Criticalf("REMOVE MEEEEE!!!!!")
+	}
 	lowHash, err = sm.findLowHashInHighHashSelectedParentChain(lowHash, highHash)
 	if err != nil {
 		return nil, err
@@ -121,7 +124,8 @@ func (sm *syncManager) getSortedMergeSet(current *externalapi.DomainHash) ([]*ex
 	}
 	sortedMergeSet = append(sortedMergeSet, blueMergeSet[i:]...)
 	sortedMergeSet = append(sortedMergeSet, redMergeSet[j:]...)
-	return blueMergeSet, nil
+
+	return sortedMergeSet, nil
 }
 
 func (sm *syncManager) findHighHashAccordingToMaxBlueScoreDifference(lowHash *externalapi.DomainHash,

--- a/domain/consensus/processes/syncmanager/antipast.go
+++ b/domain/consensus/processes/syncmanager/antipast.go
@@ -1,8 +1,8 @@
 package syncmanager
 
 import (
+	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
-	"github.com/kaspanet/kaspad/domain/consensus/utils/hashset"
 	"github.com/pkg/errors"
 )
 
@@ -17,19 +17,10 @@ func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.Doma
 	// highHash's selectedParentChain.
 	// We keep originalLowHash to filter out blocks in it's past later down the road
 	originalLowHash := lowHash
-	for {
-		isInSelectedParentChain, err := sm.dagTopologyManager.IsInSelectedParentChainOf(lowHash, highHash)
-		if err != nil {
-			return nil, err
-		}
-		if isInSelectedParentChain {
-			break
-		}
-		lowBlockGHOSTDAGData, err := sm.ghostdagDataStore.Get(sm.databaseContext, lowHash)
-		if err != nil {
-			return nil, err
-		}
-		lowHash = lowBlockGHOSTDAGData.SelectedParent()
+	var err error
+	lowHash, err = sm.findLowHashInHighHashSelectedParentChain(lowHash, highHash)
+	if err != nil {
+		return nil, err
 	}
 
 	lowBlockGHOSTDAGData, err := sm.ghostdagDataStore.Get(sm.databaseContext, lowHash)
@@ -55,78 +46,125 @@ func (sm *syncManager) antiPastHashesBetween(lowHash, highHash *externalapi.Doma
 		// Using blueScore as an approximation is considered to be
 		// fairly accurate because we presume that most DAG blocks are
 		// blue.
-		iterator, err := sm.dagTraversalManager.SelectedChildIterator(highHash, lowHash)
+		highHash, err = sm.findHighHashAccordingToMaxBlueScoreDifference(lowHash, highHash, maxBlueScoreDifference, highBlockGHOSTDAGData, lowBlockGHOSTDAGData)
 		if err != nil {
 			return nil, err
 		}
-		for ok := iterator.First(); ok; ok = iterator.Next() {
-			highHash, err = iterator.Get()
-			if err != nil {
-				return nil, err
-			}
-			highBlockGHOSTDAGData, err = sm.ghostdagDataStore.Get(sm.databaseContext, highHash)
-			if err != nil {
-				return nil, err
-			}
-			if highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore()+1 > maxBlueScoreDifference {
-				break
-			}
-		}
 	}
 
-	// Collect every node in highHash's past (including itself) but
-	// NOT in the lowHash's past (excluding itself) into an up-heap
-	// (a heap sorted by blueScore from lowest to greatest).
-	visited := hashset.New()
-	hashesUpHeap := sm.dagTraversalManager.NewUpHeap()
-	queue := sm.dagTraversalManager.NewDownHeap()
-	err = queue.Push(highHash)
+	// Collect all hashes by concatenating the merge-sets of all blocks between highHash and lowHash
+	blockHashes := []*externalapi.DomainHash{}
+	iterator, err := sm.dagTraversalManager.SelectedChildIterator(highHash, lowHash)
 	if err != nil {
 		return nil, err
 	}
-	for queue.Len() > 0 {
-		current := queue.Pop()
-		if visited.Contains(current) {
-			continue
-		}
-		visited.Add(current)
-		var isCurrentAncestorOfLowHash bool
-		if current == lowHash {
-			isCurrentAncestorOfLowHash = false
-		} else {
-			var err error
-			isCurrentAncestorOfLowHash, err = sm.dagTopologyManager.IsAncestorOf(current, lowHash)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if isCurrentAncestorOfLowHash {
-			continue
-		}
-		// Push current to hashesUpHeap if it's not in the past of originalLowHash
-		isInPastOfOriginalLowHash, err := sm.dagTopologyManager.IsAncestorOf(current, originalLowHash)
+	for ok := iterator.First(); ok; ok = iterator.Next() {
+		current, err := iterator.Get()
 		if err != nil {
 			return nil, err
 		}
-		if !isInPastOfOriginalLowHash {
-			err = hashesUpHeap.Push(current)
-			if err != nil {
-				return nil, err
-			}
-		}
-		parents, err := sm.dagTopologyManager.Parents(current)
+		// Both blue and red merge sets are topologically sorted, but not the concatenation of the two.
+		// We require the blocks to be topologically sorted. In addition,  for optimal performance,
+		// we want the selectedParent to be first.
+		// Since the rest of the merge set is in the anticone of selectedParent, it's position in the list does not
+		// matter, even though it's blue score is the highest, we can arbitrarily decide it comes first.
+		// Therefore we first append the selectedParent, then the rest of blocks in ghostdag order.
+		sortedMergeSet, err := sm.getSortedMergeSet(current)
 		if err != nil {
 			return nil, err
 		}
-		for _, parent := range parents {
-			err := queue.Push(parent)
+
+		// append to blockHashes all blocks in sortedMergeSet which are not in the past of originalLowHash
+		for _, blockHash := range sortedMergeSet {
+			isInPastOfOriginalLowHash, err := sm.dagTopologyManager.IsAncestorOf(originalLowHash, blockHash)
 			if err != nil {
 				return nil, err
 			}
+			if isInPastOfOriginalLowHash {
+				continue
+			}
+			blockHashes = append(blockHashes, blockHash)
 		}
 	}
+	return blockHashes, nil
+}
 
-	return hashesUpHeap.ToSlice(), nil
+func (sm *syncManager) getSortedMergeSet(current *externalapi.DomainHash) ([]*externalapi.DomainHash, error) {
+	currentGhostdagData, err := sm.ghostdagDataStore.Get(sm.databaseContext, current)
+	if err != nil {
+		return nil, err
+	}
+
+	blueMergeSet := currentGhostdagData.MergeSetBlues()
+	redMergeSet := currentGhostdagData.MergeSetReds()
+	selectedParent, blueMergeSet := blueMergeSet[0], blueMergeSet[1:]
+	sortedMergeSet := make([]*externalapi.DomainHash, len(blueMergeSet)+len(redMergeSet))
+	sortedMergeSet = append(sortedMergeSet, selectedParent)
+	i, j := 0, 0
+	for i < len(blueMergeSet) && j < len(redMergeSet) {
+		currentBlue := blueMergeSet[i]
+		currentBlueGhostdagData, err := sm.ghostdagDataStore.Get(sm.databaseContext, currentBlue)
+		if err != nil {
+			return nil, err
+		}
+		currentRed := redMergeSet[j]
+		currentRedGhostdagData, err := sm.ghostdagDataStore.Get(sm.databaseContext, currentRed)
+		if err != nil {
+			return nil, err
+		}
+		if sm.ghostdagManager.Less(currentBlue, currentBlueGhostdagData, currentRed, currentRedGhostdagData) {
+			sortedMergeSet = append(sortedMergeSet, currentBlue)
+			i++
+		} else {
+			sortedMergeSet = append(sortedMergeSet, currentRed)
+		}
+	}
+	sortedMergeSet = append(sortedMergeSet, blueMergeSet[i:]...)
+	sortedMergeSet = append(sortedMergeSet, redMergeSet[j:]...)
+	return blueMergeSet, nil
+}
+
+func (sm *syncManager) findHighHashAccordingToMaxBlueScoreDifference(lowHash *externalapi.DomainHash,
+	highHash *externalapi.DomainHash, maxBlueScoreDifference uint64, highBlockGHOSTDAGData *model.BlockGHOSTDAGData,
+	lowBlockGHOSTDAGData *model.BlockGHOSTDAGData) (*externalapi.DomainHash, error) {
+
+	iterator, err := sm.dagTraversalManager.SelectedChildIterator(highHash, lowHash)
+	if err != nil {
+		return nil, err
+	}
+	for ok := iterator.First(); ok; ok = iterator.Next() {
+		highHash, err = iterator.Get()
+		if err != nil {
+			return nil, err
+		}
+		highBlockGHOSTDAGData, err = sm.ghostdagDataStore.Get(sm.databaseContext, highHash)
+		if err != nil {
+			return nil, err
+		}
+		if highBlockGHOSTDAGData.BlueScore()-lowBlockGHOSTDAGData.BlueScore()+1 > maxBlueScoreDifference {
+			break
+		}
+	}
+	return highHash, nil
+}
+
+func (sm *syncManager) findLowHashInHighHashSelectedParentChain(
+	lowHash *externalapi.DomainHash, highHash *externalapi.DomainHash) (*externalapi.DomainHash, error) {
+	for {
+		isInSelectedParentChain, err := sm.dagTopologyManager.IsInSelectedParentChainOf(lowHash, highHash)
+		if err != nil {
+			return nil, err
+		}
+		if isInSelectedParentChain {
+			break
+		}
+		lowBlockGHOSTDAGData, err := sm.ghostdagDataStore.Get(sm.databaseContext, lowHash)
+		if err != nil {
+			return nil, err
+		}
+		lowHash = lowBlockGHOSTDAGData.SelectedParent()
+	}
+	return lowHash, nil
 }
 
 func (sm *syncManager) missingBlockBodyHashes(highHash *externalapi.DomainHash) ([]*externalapi.DomainHash, error) {

--- a/domain/consensus/processes/syncmanager/syncmanager_test.go
+++ b/domain/consensus/processes/syncmanager/syncmanager_test.go
@@ -44,10 +44,6 @@ func TestSyncManager_GetHashesBetween(t *testing.T) {
 			}
 			sort.Sort(sort.Reverse(testutils.NewTestGhostDAGSorter(splitBlocks, tc, t)))
 			restOfSplitBlocks, selectedParent := splitBlocks[:len(splitBlocks)-1], splitBlocks[len(splitBlocks)-1]
-			selectedParent, err := tc.GHOSTDAGManager().ChooseSelectedParent(splitBlocks...)
-			if err != nil {
-				return
-			}
 			expectedOrder = append(expectedOrder, selectedParent)
 			expectedOrder = append(expectedOrder, restOfSplitBlocks...)
 
@@ -68,13 +64,13 @@ func TestSyncManager_GetHashesBetween(t *testing.T) {
 			}
 		}
 
-		allHashes, err := tc.SyncManager().GetHashesBetween(params.GenesisHash, expectedOrder[len(expectedOrder)-1], math.MaxUint64)
+		actualOrder, err := tc.SyncManager().GetHashesBetween(params.GenesisHash, expectedOrder[len(expectedOrder)-1], math.MaxUint64)
 		if err != nil {
-			t.Fatalf("TestSyncManager_GetHashesBetween failed returning allHashes: %v", err)
+			t.Fatalf("TestSyncManager_GetHashesBetween failed returning actualOrder: %v", err)
 		}
 
-		if !reflect.DeepEqual(allHashes, expectedOrder) {
-			t.Fatalf("TestSyncManager_GetHashesBetween expected: \n%s\nactual:\n%s\n", expectedOrder, allHashes)
+		if !reflect.DeepEqual(actualOrder, expectedOrder) {
+			t.Fatalf("TestSyncManager_GetHashesBetween expected: \n%s\nactual:\n%s\n", expectedOrder, actualOrder)
 		}
 	})
 }

--- a/domain/consensus/processes/syncmanager/syncmanager_test.go
+++ b/domain/consensus/processes/syncmanager/syncmanager_test.go
@@ -21,27 +21,44 @@ func TestSyncManager_GetHashesBetween(t *testing.T) {
 		}
 		defer teardown(false)
 
-		upBfsOrder := make([]*externalapi.DomainHash, 0, 30)
-		selectedParent := params.GenesisHash
-		upBfsOrder = append(upBfsOrder, selectedParent)
+		// Create a DAG with the following structure:
+		//          merging block
+		//         /      |      \
+		//      split1  split2   split3
+		//        \       |      /
+		//         merging block
+		//         /      |      \
+		//      split1  split2   split3
+		//        \       |      /
+		//               etc.
+		expectedOrder := make([]*externalapi.DomainHash, 0, 40)
+		mergingBlock := params.GenesisHash
 		for i := 0; i < 10; i++ {
-			parents := make([]*externalapi.DomainHash, 0, 3)
-			for j := 0; j < 4; j++ {
-				blockHash, _, err := tc.AddBlock([]*externalapi.DomainHash{selectedParent}, nil, nil)
+			splitBlocks := make([]*externalapi.DomainHash, 0, 3)
+			for j := 0; j < 3; j++ {
+				splitBlock, _, err := tc.AddBlock([]*externalapi.DomainHash{mergingBlock}, nil, nil)
 				if err != nil {
 					t.Fatalf("Failed adding block: %v", err)
 				}
-				parents = append(parents, blockHash)
-				upBfsOrder = append(upBfsOrder, blockHash)
+				splitBlocks = append(splitBlocks, splitBlock)
 			}
-			selectedParent, _, err = tc.AddBlock(parents, nil, nil)
+			sort.Sort(sort.Reverse(testutils.NewTestGhostDAGSorter(splitBlocks, tc, t)))
+			restOfSplitBlocks, selectedParent := splitBlocks[:len(splitBlocks)-1], splitBlocks[len(splitBlocks)-1]
+			selectedParent, err := tc.GHOSTDAGManager().ChooseSelectedParent(splitBlocks...)
+			if err != nil {
+				return
+			}
+			expectedOrder = append(expectedOrder, selectedParent)
+			expectedOrder = append(expectedOrder, restOfSplitBlocks...)
+
+			mergingBlock, _, err = tc.AddBlock(splitBlocks, nil, nil)
 			if err != nil {
 				t.Fatalf("Failed adding block: %v", err)
 			}
-			upBfsOrder = append(upBfsOrder, selectedParent)
+			expectedOrder = append(expectedOrder, mergingBlock)
 		}
 
-		for i, blockHash := range upBfsOrder {
+		for i, blockHash := range expectedOrder {
 			empty, err := tc.SyncManager().GetHashesBetween(blockHash, blockHash, math.MaxUint64)
 			if err != nil {
 				t.Fatalf("TestSyncManager_GetHashesBetween failed returning 0 hashes on the %d'th block: %v", i, err)
@@ -51,15 +68,13 @@ func TestSyncManager_GetHashesBetween(t *testing.T) {
 			}
 		}
 
-		allHashes, err := tc.SyncManager().GetHashesBetween(upBfsOrder[0], upBfsOrder[len(upBfsOrder)-1], math.MaxUint64)
+		allHashes, err := tc.SyncManager().GetHashesBetween(params.GenesisHash, expectedOrder[len(expectedOrder)-1], math.MaxUint64)
 		if err != nil {
 			t.Fatalf("TestSyncManager_GetHashesBetween failed returning allHashes: %v", err)
 		}
 
-		sort.Sort(sort.Reverse(testutils.NewTestGhostDAGSorter(upBfsOrder, tc, t)))
-		upBfsOrderExcludingGenesis := upBfsOrder[1:]
-		if !reflect.DeepEqual(allHashes, upBfsOrderExcludingGenesis) {
-			t.Fatalf("TestSyncManager_GetHashesBetween expected: \n%s\nactual:\n%s\n", upBfsOrderExcludingGenesis, allHashes)
+		if !reflect.DeepEqual(allHashes, expectedOrder) {
+			t.Fatalf("TestSyncManager_GetHashesBetween expected: \n%s\nactual:\n%s\n", expectedOrder, allHashes)
 		}
 	})
 }

--- a/domain/consensus/processes/syncmanager/syncmanager_test.go
+++ b/domain/consensus/processes/syncmanager/syncmanager_test.go
@@ -1,14 +1,15 @@
 package syncmanager_test
 
 import (
-	"github.com/kaspanet/kaspad/domain/consensus"
-	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
-	"github.com/kaspanet/kaspad/domain/consensus/utils/testutils"
-	"github.com/kaspanet/kaspad/domain/dagconfig"
 	"math"
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/kaspanet/kaspad/domain/consensus"
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"github.com/kaspanet/kaspad/domain/consensus/utils/testutils"
+	"github.com/kaspanet/kaspad/domain/dagconfig"
 )
 
 func TestSyncManager_GetHashesBetween(t *testing.T) {
@@ -58,7 +59,7 @@ func TestSyncManager_GetHashesBetween(t *testing.T) {
 		sort.Sort(sort.Reverse(testutils.NewTestGhostDAGSorter(upBfsOrder, tc, t)))
 		upBfsOrderExcludingGenesis := upBfsOrder[1:]
 		if !reflect.DeepEqual(allHashes, upBfsOrderExcludingGenesis) {
-			t.Fatalf("TestSyncManager_GetHashesBetween expected %v\n == \n%v", allHashes, upBfsOrder)
+			t.Fatalf("TestSyncManager_GetHashesBetween expected: \n%s\nactual:\n%s\n", upBfsOrderExcludingGenesis, allHashes)
 		}
 	})
 }

--- a/domain/consensus/test_consensus.go
+++ b/domain/consensus/test_consensus.go
@@ -2,6 +2,8 @@ package consensus
 
 import (
 	"encoding/json"
+	"io"
+
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/consensus/model/testapi"
@@ -9,7 +11,6 @@ import (
 	"github.com/kaspanet/kaspad/domain/dagconfig"
 	"github.com/kaspanet/kaspad/infrastructure/db/database"
 	"github.com/pkg/errors"
-	"io"
 )
 
 type testConsensus struct {

--- a/domain/consensus/test_consensus_render_to_dot.go
+++ b/domain/consensus/test_consensus_render_to_dot.go
@@ -1,0 +1,76 @@
+package consensus
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+)
+
+// RenderDAGToDot is a helper function for debugging tests.
+// It requires graphviz installed.
+func (tc *testConsensus) RenderDAGToDot(filename string) error {
+	dotScript, _ := tc.convertToDot()
+	return renderDotScript(dotScript, filename)
+}
+
+func (tc *testConsensus) convertToDot() (string, error) {
+	var dotScriptBuilder strings.Builder
+	dotScriptBuilder.WriteString("digraph {\n\trankdir = TB; \n")
+
+	edges := []string{}
+
+	blocksIterator, err := tc.blockStore.AllBlockHashesIterator(tc.databaseContext)
+	if err != nil {
+		return "", err
+	}
+
+	for ok := blocksIterator.First(); ok; ok = blocksIterator.Next() {
+		hash, err := blocksIterator.Get()
+		if err != nil {
+			return "", err
+		}
+		dotScriptBuilder.WriteString(fmt.Sprintf("\t\"%s\";\n", hash))
+
+		parents, err := tc.dagTopologyManager.Parents(hash)
+
+		for _, parentHash := range parents {
+			edges = append(edges, fmt.Sprintf("\t\"%s\" -> \"%s\";", hash, parentHash))
+		}
+	}
+
+	dotScriptBuilder.WriteString("\n")
+
+	dotScriptBuilder.WriteString(strings.Join(edges, "\n"))
+
+	dotScriptBuilder.WriteString("\n}")
+
+	return dotScriptBuilder.String(), nil
+}
+
+func renderDotScript(dotScript string, filename string) error {
+	command := exec.Command("dot", "-Tsvg")
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("Error creating stdin pipe: %s", err)
+	}
+	spawn("renderDotScript", func() {
+		defer stdin.Close()
+
+		_, err = io.WriteString(stdin, dotScript)
+		if err != nil {
+			panic(fmt.Errorf("Error writing dotScript into stdin pipe: %s", err))
+		}
+	})
+
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	svg, err := command.Output()
+	if err != nil {
+		return fmt.Errorf("Error getting output of dot: %s\nstderr:\n%s", err, stderr.String())
+	}
+
+	return ioutil.WriteFile(filename, svg, 0600)
+}

--- a/domain/consensus/test_consensus_render_to_dot.go
+++ b/domain/consensus/test_consensus_render_to_dot.go
@@ -35,6 +35,9 @@ func (tc *testConsensus) convertToDot() (string, error) {
 		dotScriptBuilder.WriteString(fmt.Sprintf("\t\"%s\";\n", hash))
 
 		parents, err := tc.dagTopologyManager.Parents(hash)
+		if err != nil {
+			return "", err
+		}
 
 		for _, parentHash := range parents {
 			edges = append(edges, fmt.Sprintf("\t\"%s\" -> \"%s\";", hash, parentHash))


### PR DESCRIPTION
This PR fixes a performance bug in IBD:

Currently IBD synced block bodies in BFS order, validating against their UTXO-Set blocks that would later not be in the selected-parent-chain. Those blocks are then left as virtualDiffParents, forcing us to update diffs between them and virtual until those are merged.

This PR re-orders the list of blocks returned by antiPastHashesBetween to be in an order where the selectedParent is always first, thus he is the only block in it's merge set that will be validated against UTXO-Set.