### PR TITLE
Mine faster - don't parse the whole block every time you try a nonce (kaspaminer, non critical)

### DIFF
--- a/cmd/kaspaminer/mineloop.go
+++ b/cmd/kaspaminer/mineloop.go
@@ -159,7 +159,7 @@ func getBlockForMining(mineWhenNotSynced bool) *externalapi.DomainBlock {
 		tryCount++
 		const sleepTime = 500 * time.Millisecond
 		shouldLog := (tryCount-1)%10 == 0
-		template := templatemanager.Get()
+		template, isSynced := templatemanager.Get()
 		if template == nil {
 			if shouldLog {
 				log.Info("Waiting for the initial template")
@@ -167,7 +167,7 @@ func getBlockForMining(mineWhenNotSynced bool) *externalapi.DomainBlock {
 			time.Sleep(sleepTime)
 			continue
 		}
-		if !template.IsSynced && !mineWhenNotSynced {
+		if !isSynced && !mineWhenNotSynced {
 			if shouldLog {
 				log.Warnf("Kaspad is not synced. Skipping current block template")
 			}
@@ -175,7 +175,7 @@ func getBlockForMining(mineWhenNotSynced bool) *externalapi.DomainBlock {
 			continue
 		}
 
-		return appmessage.MsgBlockToDomainBlock(template.MsgBlock)
+		return template
 	}
 }
 

--- a/cmd/kaspaminer/templatemanager/templatemanager.go
+++ b/cmd/kaspaminer/templatemanager/templatemanager.go
@@ -2,22 +2,31 @@ package templatemanager
 
 import (
 	"github.com/kaspanet/kaspad/app/appmessage"
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"sync"
 )
 
-var currentTemplate *appmessage.GetBlockTemplateResponseMessage
+var currentTemplate *externalapi.DomainBlock
+var isSynced bool
 var lock = &sync.Mutex{}
 
 // Get returns the template to work on
-func Get() *appmessage.GetBlockTemplateResponseMessage {
+func Get() (*externalapi.DomainBlock, bool) {
 	lock.Lock()
 	defer lock.Unlock()
-	return currentTemplate
+	// Shallow copy the block so when the user replaces the header it won't affect the template here.
+	if currentTemplate == nil {
+		return nil, false
+	}
+	block := *currentTemplate
+	return &block, isSynced
 }
 
 // Set sets the current template to work on
 func Set(template *appmessage.GetBlockTemplateResponseMessage) {
+	block := appmessage.MsgBlockToDomainBlock(template.MsgBlock)
 	lock.Lock()
 	defer lock.Unlock()
-	currentTemplate = template
+	currentTemplate = block
+	isSynced = template.IsSynced
 }


### PR DESCRIPTION
Right now on every nonce increase we get the `GetBlockTemplateResponseMessage`, parse it into a `DomainBlock`, try a nonce and all over again.
Instead parse `GetBlockTemplateResponseMessage` into a `DomainBlock` once per template when setting the block.
There's no danger in concurrent access because the block itself is "copied" and, the header is immutable anyway, and there's no reason for anything to touch the transactions in the miner(it will invalidate the header).

On my machine, hashrate before:
`2021-02-17 22:10:16.406 [INF] KSMN: Current hash rate is 155.93 Khash/s`

After:
`2021-02-17 22:22:03.845 [INF] KSMN: Current hash rate is 517.68 Khash/s`