### PR TITLE
Make the CI more verbose and cache kaspad dependencies in the dockerfile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Test
         shell: bash
-        run: ./build_and_test.sh
+        run: ./build_and_test.sh -v
 
   coverage:
     runs-on: ubuntu-20.04
@@ -63,7 +63,7 @@ jobs:
           go-version: 1.15
 
       - name: Create coverage file
-        run: go test -covermode=atomic -coverpkg=./... -coverprofile coverage.txt ./...
+        run: go test -v -covermode=atomic -coverpkg=./... -coverprofile coverage.txt ./...
 
       - name: Upload coverage file
         run: bash <(curl -s https://codecov.io/bash)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,9 @@ RUN go get -u golang.org/x/lint/golint \
 COPY go.mod .
 COPY go.sum .
 
+# Cache kaspad dependencies
+RUN go mod download
+
 COPY . .
 
 RUN NO_PARALLEL=1 ./build_and_test.sh


### PR DESCRIPTION
This might help us solve the nondeterministic failures that only happen in the CI