### PR TITLE
Github Actions - Don't cancel the rest of the jobs if one failed

### DIFF
--- a/.github/workflows/go-race.yml
+++ b/.github/workflows/go-race.yml
@@ -9,6 +9,7 @@ jobs:
   race_test:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         branch: [ master, latest ]
     name: Race detection on ${{ matrix.branch }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-16.04, macos-10.15 ]
     name: Testing on on ${{ matrix.os }}


### PR DESCRIPTION
Currently if one job fails github actions will cancel the rest of the jobs, this prevents that,
(e.g. we want the race detector to continue running on 0.9.0 even if it failed on master)