### PR TITLE
Fix subnetworks FromString and disable reversal

### DIFF
--- a/app/appmessage/domainconverters.go
+++ b/app/appmessage/domainconverters.go
@@ -164,11 +164,7 @@ func outpointToDomainOutpoint(outpoint *Outpoint) *externalapi.DomainOutpoint {
 func RPCTransactionToDomainTransaction(rpcTransaction *RPCTransaction) (*externalapi.DomainTransaction, error) {
 	inputs := make([]*externalapi.DomainTransactionInput, len(rpcTransaction.Inputs))
 	for i, input := range rpcTransaction.Inputs {
-		transactionIDBytes, err := hex.DecodeString(input.PreviousOutpoint.TransactionID)
-		if err != nil {
-			return nil, err
-		}
-		transactionID, err := transactionid.FromBytes(transactionIDBytes)
+		transactionID, err := transactionid.FromString(input.PreviousOutpoint.TransactionID)
 		if err != nil {
 			return nil, err
 		}
@@ -198,19 +194,11 @@ func RPCTransactionToDomainTransaction(rpcTransaction *RPCTransaction) (*externa
 		}
 	}
 
-	subnetworkIDBytes, err := hex.DecodeString(rpcTransaction.SubnetworkID)
+	subnetworkID, err := subnetworks.FromString(rpcTransaction.SubnetworkID)
 	if err != nil {
 		return nil, err
 	}
-	subnetworkID, err := subnetworks.FromBytes(subnetworkIDBytes)
-	if err != nil {
-		return nil, err
-	}
-	payloadHashBytes, err := hex.DecodeString(rpcTransaction.PayloadHash)
-	if err != nil {
-		return nil, err
-	}
-	payloadHash, err := externalapi.NewDomainHashFromByteSlice(payloadHashBytes)
+	payloadHash, err := externalapi.NewDomainHashFromString(rpcTransaction.PayloadHash)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +243,7 @@ func DomainTransactionToRPCTransaction(transaction *externalapi.DomainTransactio
 			ScriptPublicKey: &RPCScriptPublicKey{Script: scriptPublicKey, Version: output.ScriptPublicKey.Version},
 		}
 	}
-	subnetworkID := hex.EncodeToString(transaction.SubnetworkID[:])
+	subnetworkID := transaction.SubnetworkID.String()
 	payloadHash := transaction.PayloadHash.String()
 	payload := hex.EncodeToString(transaction.Payload)
 	return &RPCTransaction{

--- a/domain/consensus/model/externalapi/subnetworkid.go
+++ b/domain/consensus/model/externalapi/subnetworkid.go
@@ -10,9 +10,6 @@ type DomainSubnetworkID [DomainSubnetworkIDSize]byte
 
 // String stringifies a subnetwork ID.
 func (id DomainSubnetworkID) String() string {
-	for i := 0; i < DomainSubnetworkIDSize/2; i++ {
-		id[i], id[DomainSubnetworkIDSize-1-i] = id[DomainSubnetworkIDSize-1-i], id[i]
-	}
 	return hex.EncodeToString(id[:])
 }
 

--- a/domain/consensus/utils/subnetworks/compare.go
+++ b/domain/consensus/utils/subnetworks/compare.go
@@ -1,23 +1,11 @@
 package subnetworks
 
 import (
+	"bytes"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 )
 
-func cmp(a, b externalapi.DomainSubnetworkID) int {
-	// We compare the hashes backwards because Hash is stored as a little endian byte array.
-	for i := externalapi.DomainSubnetworkIDSize - 1; i >= 0; i-- {
-		switch {
-		case a[i] < b[i]:
-			return -1
-		case a[i] > b[i]:
-			return 1
-		}
-	}
-	return 0
-}
-
 // Less returns true iff id a is less than id b
 func Less(a, b externalapi.DomainSubnetworkID) bool {
-	return cmp(a, b) < 0
+	return bytes.Compare(a[:], b[:]) < 0
 }

--- a/domain/consensus/utils/subnetworks/from_string.go
+++ b/domain/consensus/utils/subnetworks/from_string.go
@@ -8,11 +8,7 @@ import (
 
 // FromString creates a DomainSubnetworkID from the given byte slice
 func FromString(str string) (*externalapi.DomainSubnetworkID, error) {
-	runes := []rune(str)
-	for i := 0; i < externalapi.DomainSubnetworkIDSize*2; i++ {
-		runes[i], runes[externalapi.DomainSubnetworkIDSize-1-i] = runes[externalapi.DomainSubnetworkIDSize-1-i], runes[i]
-	}
-	subnetworkIDBytes, err := hex.DecodeString(string(runes))
+	subnetworkIDBytes, err := hex.DecodeString(str)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Removed DomainSubnetworkID bytes reversal.
And fixed FromString. (Before it switched each ascii letter in the hex, now it uses FromBytes)

