### PR TITLE
Merge big subdags in pick virtual parents

### DIFF
--- a/domain/consensus/model/interface_processes_dagtopologymanager.go
+++ b/domain/consensus/model/interface_processes_dagtopologymanager.go
@@ -11,6 +11,7 @@ type DAGTopologyManager interface {
 	IsChildOf(blockHashA *externalapi.DomainHash, blockHashB *externalapi.DomainHash) (bool, error)
 	IsAncestorOf(blockHashA *externalapi.DomainHash, blockHashB *externalapi.DomainHash) (bool, error)
 	IsAncestorOfAny(blockHash *externalapi.DomainHash, potentialDescendants []*externalapi.DomainHash) (bool, error)
+	IsAnyAncestorOf(potentialAncestors []*externalapi.DomainHash, blockHash *externalapi.DomainHash) (bool, error)
 	IsInSelectedParentChainOf(blockHashA *externalapi.DomainHash, blockHashB *externalapi.DomainHash) (bool, error)
 	ChildInSelectedParentChainOf(context, highHash *externalapi.DomainHash) (*externalapi.DomainHash, error)
 

--- a/domain/consensus/processes/dagtopologymanager/dagtopologymanager.go
+++ b/domain/consensus/processes/dagtopologymanager/dagtopologymanager.go
@@ -87,6 +87,22 @@ func (dtm *dagTopologyManager) IsAncestorOfAny(blockHash *externalapi.DomainHash
 	return false, nil
 }
 
+// IsAnyAncestorOf returns true if at least one of `potentialAncestors` is an ancestor of `blockHash`
+func (dtm *dagTopologyManager) IsAnyAncestorOf(potentialAncestors []*externalapi.DomainHash, blockHash *externalapi.DomainHash) (bool, error) {
+	for _, potentialAncestor := range potentialAncestors {
+		isAncestorOf, err := dtm.IsAncestorOf(potentialAncestor, blockHash)
+		if err != nil {
+			return false, err
+		}
+
+		if isAncestorOf {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // IsInSelectedParentChainOf returns true if blockHashA is in the selected parent chain of blockHashB
 func (dtm *dagTopologyManager) IsInSelectedParentChainOf(blockHashA *externalapi.DomainHash, blockHashB *externalapi.DomainHash) (bool, error) {
 	return dtm.reachabilityManager.IsReachabilityTreeAncestorOf(blockHashA, blockHashB)

--- a/domain/consensus/processes/ghostdagmanager/ghostdag_test.go
+++ b/domain/consensus/processes/ghostdagmanager/ghostdag_test.go
@@ -390,6 +390,9 @@ func (dt *DAGTopologyManagerImpl) IsAncestorOf(hashBlockA *externalapi.DomainHas
 func (dt *DAGTopologyManagerImpl) IsAncestorOfAny(blockHash *externalapi.DomainHash, potentialDescendants []*externalapi.DomainHash) (bool, error) {
 	panic("unimplemented")
 }
+func (dt *DAGTopologyManagerImpl) IsAnyAncestorOf([]*externalapi.DomainHash, *externalapi.DomainHash) (bool, error) {
+	panic("unimplemented")
+}
 func (dt *DAGTopologyManagerImpl) IsInSelectedParentChainOf(blockHashA *externalapi.DomainHash, blockHashB *externalapi.DomainHash) (bool, error) {
 	panic("unimplemented")
 }


### PR DESCRIPTION
This should:
1. Improve the performance of processing blocks when there's a big subdag.
2. Slowly merge said subdag by slowly climbing down the merge set