### PR TITLE
Fix a data race in GetBlockChildren

### DIFF
--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -158,6 +158,8 @@ func (s *consensus) GetBlockInfo(blockHash *externalapi.DomainHash) (*externalap
 }
 
 func (s *consensus) GetBlockChildren(blockHash *externalapi.DomainHash) ([]*externalapi.DomainHash, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	blockRelation, err := s.blockRelationStore.BlockRelation(s.databaseContext, blockHash)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Intorduced in https://github.com/kaspanet/kaspad/pull/1560, `GetBlockChildren` didn't lock the consensus mutex