### PR TITLE
Delete the stability tests when doing code coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,6 +63,9 @@ jobs:
         with:
           go-version: 1.16
 
+      - name: Delete the stability tests from coverage
+        run: rm -r stability-tests
+
       - name: Create coverage file
         run: go test -v -covermode=atomic -coverpkg=./... -coverprofile coverage.txt ./...
 


### PR DESCRIPTION
Since #1587 the code coverage is broken.
The easiest fix is to just delete the stability tests when doing code coverage.

In the future we should probably:
1. Remove init functions from stability tests.
2. Convert them into unit tests (I think).