### PR TITLE
Replace the HomeDir flag with a AppDir flag

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -171,7 +171,7 @@ func doUpgrades() error {
 
 // dbPath returns the path to the block database given a database type.
 func databasePath(cfg *config.Config) string {
-	return filepath.Join(cfg.HomeDir, "data")
+	return filepath.Join(cfg.AppDir, "data")
 }
 
 func removeDatabase(cfg *config.Config) error {

--- a/cmd/kaspaminer/config.go
+++ b/cmd/kaspaminer/config.go
@@ -24,9 +24,9 @@ const (
 
 var (
 	// Default configuration options
-	defaultHomeDir    = util.AppDataDir("kaspaminer", false)
-	defaultLogFile    = filepath.Join(defaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(defaultHomeDir, defaultErrLogFilename)
+	defaultAppDir     = util.AppDir("kaspaminer", false)
+	defaultLogFile    = filepath.Join(defaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(defaultAppDir, defaultErrLogFilename)
 	defaultRPCServer  = "localhost"
 )
 

--- a/infrastructure/config/config.go
+++ b/infrastructure/config/config.go
@@ -54,13 +54,13 @@ const (
 )
 
 var (
-	// DefaultHomeDir is the default home directory for kaspad.
-	DefaultHomeDir = util.AppDataDir("kaspad", false)
+	// DefaultAppDir is the default home directory for kaspad.
+	DefaultAppDir = util.AppDir("kaspad", false)
 
-	defaultConfigFile  = filepath.Join(DefaultHomeDir, defaultConfigFilename)
-	defaultDataDir     = filepath.Join(DefaultHomeDir)
-	defaultRPCKeyFile  = filepath.Join(DefaultHomeDir, "rpc.key")
-	defaultRPCCertFile = filepath.Join(DefaultHomeDir, "rpc.cert")
+	defaultConfigFile  = filepath.Join(DefaultAppDir, defaultConfigFilename)
+	defaultDataDir     = filepath.Join(DefaultAppDir)
+	defaultRPCKeyFile  = filepath.Join(DefaultAppDir, "rpc.key")
+	defaultRPCCertFile = filepath.Join(DefaultAppDir, "rpc.cert")
 )
 
 // RunServiceCommand is only set to a real function on Windows. It is used
@@ -73,7 +73,7 @@ var RunServiceCommand func(string) error
 type Flags struct {
 	ShowVersion          bool          `short:"V" long:"version" description:"Display version information and exit"`
 	ConfigFile           string        `short:"C" long:"configfile" description:"Path to configuration file"`
-	HomeDir              string        `short:"b" long:"homedir" description:"Directory to store data"`
+	AppDir               string        `short:"b" long:"appdir" description:"Directory to store data"`
 	LogDir               string        `long:"logdir" description:"Directory to log output."`
 	AddPeers             []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
 	ConnectPeers         []string      `long:"connect" description:"Connect only to the specified peers at startup"`
@@ -144,7 +144,7 @@ type ServiceOptions struct {
 func cleanAndExpandPath(path string) string {
 	// Expand initial ~ to OS specific home directory.
 	if strings.HasPrefix(path, "~") {
-		homeDir := filepath.Dir(DefaultHomeDir)
+		homeDir := filepath.Dir(DefaultAppDir)
 		path = strings.Replace(path, "~", homeDir, 1)
 	}
 
@@ -173,7 +173,7 @@ func defaultFlags() *Flags {
 		RPCMaxClients:        defaultMaxRPCClients,
 		RPCMaxWebsockets:     defaultMaxRPCWebsockets,
 		RPCMaxConcurrentReqs: defaultMaxRPCConcurrentReqs,
-		HomeDir:              defaultDataDir,
+		AppDir:               defaultDataDir,
 		RPCKey:               defaultRPCKeyFile,
 		RPCCert:              defaultRPCCertFile,
 		BlockMaxMass:         defaultBlockMaxMass,
@@ -266,7 +266,7 @@ func LoadConfig() (*Config, error) {
 
 	// Create the home directory if it doesn't already exist.
 	funcName := "loadConfig"
-	err = os.MkdirAll(DefaultHomeDir, 0700)
+	err = os.MkdirAll(DefaultAppDir, 0700)
 	if err != nil {
 		// Show a nicer error message if it's because a symlink is
 		// linked to a directory that does not exist (probably because
@@ -309,17 +309,17 @@ func LoadConfig() (*Config, error) {
 	}
 	cfg.RelayNonStd = relayNonStd
 
-	cfg.HomeDir = cleanAndExpandPath(cfg.HomeDir)
-	// Append the network type to the home directory so it is "namespaced"
+	cfg.AppDir = cleanAndExpandPath(cfg.AppDir)
+	// Append the network type to the app directory so it is "namespaced"
 	// per network.
 	// All data is specific to a network, so namespacing the data directory
 	// means each individual piece of serialized data does not have to
 	// worry about changing names per network and such.
-	cfg.HomeDir = filepath.Join(cfg.HomeDir, cfg.NetParams().Name)
+	cfg.AppDir = filepath.Join(cfg.AppDir, cfg.NetParams().Name)
 
 	// Logs directory is usually under the home directory, unless otherwise specified
 	if cfg.LogDir == "" {
-		cfg.LogDir = filepath.Join(cfg.HomeDir, defaultLogDirname)
+		cfg.LogDir = filepath.Join(cfg.AppDir, defaultLogDirname)
 	}
 	cfg.LogDir = cleanAndExpandPath(cfg.LogDir)
 

--- a/stability-tests/application-level-garbage/config.go
+++ b/stability-tests/application-level-garbage/config.go
@@ -18,8 +18,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/common/paths.go
+++ b/stability-tests/common/paths.go
@@ -2,5 +2,5 @@ package common
 
 import "github.com/kaspanet/kaspad/util"
 
-// DefaultHomeDir is the default home directory to be used by all tests
-var DefaultHomeDir = util.AppDataDir("stability-tests", false)
+// DefaultAppDir is the default app directory to be used by all tests
+var DefaultAppDir = util.AppDir("stability-tests", false)

--- a/stability-tests/infra-level-garbage/config.go
+++ b/stability-tests/infra-level-garbage/config.go
@@ -18,8 +18,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/kaspadsanity/config.go
+++ b/stability-tests/kaspadsanity/config.go
@@ -14,8 +14,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/minejson/config.go
+++ b/stability-tests/minejson/config.go
@@ -18,8 +18,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/netsync/chain_generator/config.go
+++ b/stability-tests/netsync/chain_generator/config.go
@@ -14,8 +14,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/netsync/config.go
+++ b/stability-tests/netsync/config.go
@@ -16,8 +16,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/orphans/config.go
+++ b/stability-tests/orphans/config.go
@@ -19,8 +19,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/reorg/config.go
+++ b/stability-tests/reorg/config.go
@@ -17,8 +17,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/rpc-idle-clients/config.go
+++ b/stability-tests/rpc-idle-clients/config.go
@@ -17,8 +17,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/rpc-stability/config.go
+++ b/stability-tests/rpc-stability/config.go
@@ -18,8 +18,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/stability-tests/simple-sync/config.go
+++ b/stability-tests/simple-sync/config.go
@@ -15,8 +15,8 @@ const (
 
 var (
 	// Default configuration options
-	defaultLogFile    = filepath.Join(common.DefaultHomeDir, defaultLogFilename)
-	defaultErrLogFile = filepath.Join(common.DefaultHomeDir, defaultErrLogFilename)
+	defaultLogFile    = filepath.Join(common.DefaultAppDir, defaultLogFilename)
+	defaultErrLogFile = filepath.Join(common.DefaultAppDir, defaultErrLogFilename)
 )
 
 type configFlags struct {

--- a/testing/integration/config_test.go
+++ b/testing/integration/config_test.go
@@ -32,7 +32,7 @@ const (
 
 func setConfig(t *testing.T, harness *appHarness) {
 	harness.config = commonConfig()
-	harness.config.HomeDir = randomDirectory(t)
+	harness.config.AppDir = randomDirectory(t)
 	harness.config.Listeners = []string{harness.p2pAddress}
 	harness.config.RPCListeners = []string{harness.rpcAddress}
 	harness.config.UTXOIndex = harness.utxoIndex

--- a/testing/integration/setup_test.go
+++ b/testing/integration/setup_test.go
@@ -134,6 +134,6 @@ func setDatabaseContext(t *testing.T, harness *appHarness) {
 }
 
 func openDB(cfg *config.Config) (database.Database, error) {
-	dbPath := filepath.Join(cfg.HomeDir, "db")
+	dbPath := filepath.Join(cfg.AppDir, "db")
 	return ldb.NewLevelDB(dbPath, 8)
 }

--- a/util/appdata.go
+++ b/util/appdata.go
@@ -13,12 +13,12 @@ import (
 	"unicode"
 )
 
-// appDataDir returns an operating system specific directory to be used for
-// storing application data for an application. See AppDataDir for more
+// appDir returns an operating system specific directory to be used for
+// storing application data for an application. See AppDir for more
 // details. This unexported version takes an operating system argument
 // primarily to enable the testing package to properly test the function by
 // forcing an operating system that is not the currently one.
-func appDataDir(goos, appName string, roaming bool) string {
+func appDir(goos, appName string, roaming bool) string {
 	if appName == "" || appName == "." {
 		return "."
 	}
@@ -79,7 +79,7 @@ func appDataDir(goos, appName string, roaming bool) string {
 	return "."
 }
 
-// AppDataDir returns an operating system specific directory to be used for
+// AppDir returns an operating system specific directory to be used for
 // storing application data for an application.
 //
 // The appName parameter is the name of the application the data directory is
@@ -95,11 +95,11 @@ func appDataDir(goos, appName string, roaming bool) string {
 // (%LOCALAPPDATA%) that is used by default.
 //
 // Example results:
-//  dir := AppDataDir("myapp", false)
+//  dir := AppDir("myapp", false)
 //   POSIX (Linux/BSD): ~/.myapp
 //   Mac OS: $HOME/Library/Application Support/Myapp
 //   Windows: %LOCALAPPDATA%\Myapp
 //   Plan 9: $home/myapp
-func AppDataDir(appName string, roaming bool) string {
-	return appDataDir(runtime.GOOS, appName, roaming)
+func AppDir(appName string, roaming bool) string {
+	return appDir(runtime.GOOS, appName, roaming)
 }

--- a/util/appdata_test.go
+++ b/util/appdata_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kaspanet/kaspad/util"
 )
 
-// TestAppDataDir tests the API for AppDataDir to ensure it gives expected
+// TestAppDataDir tests the API for AppDir to ensure it gives expected
 // results for various operating systems.
 func TestAppDataDir(t *testing.T) {
 	// App name plus upper and lowercase variants.
@@ -124,7 +124,7 @@ func TestAppDataDir(t *testing.T) {
 	for i, test := range tests {
 		ret := util.TstAppDataDir(test.goos, test.appName, test.roaming)
 		if ret != test.want {
-			t.Errorf("appDataDir #%d (%s) does not match - "+
+			t.Errorf("appDir #%d (%s) does not match - "+
 				"expected got %s, want %s", i, test.goos, ret,
 				test.want)
 			continue

--- a/util/internal_test.go
+++ b/util/internal_test.go
@@ -16,10 +16,10 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
-// TstAppDataDir makes the internal appDataDir function available to the test
+// TstAppDataDir makes the internal appDir function available to the test
 // package.
 func TstAppDataDir(goos, appName string, roaming bool) string {
-	return appDataDir(goos, appName, roaming)
+	return appDir(goos, appName, roaming)
 }
 
 func TstAddressPubKeyHash(prefix Bech32Prefix, hash [ripemd160.Size]byte) *AddressPubKeyHash {


### PR DESCRIPTION
#1613 restructured the default directory, but used the name `homedir` to represent it, which is ambiguous with `~/` or `$HOME`.
so this renames it to `appdir` which should be less ambiguous 