### PR TITLE
Add a size limit to the address manager

### DIFF
--- a/infrastructure/network/addressmanager/addressmanager.go
+++ b/infrastructure/network/addressmanager/addressmanager.go
@@ -145,6 +145,8 @@ func (am *AddressManager) RemoveAddress(address *appmessage.NetAddress) error {
 	return am.removeAddressNoLock(address)
 }
 
+// MarkConnectionFailure notifies the address manager that the given address
+// has failed to connect
 func (am *AddressManager) MarkConnectionFailure(address *appmessage.NetAddress) error {
 	am.mutex.Lock()
 	defer am.mutex.Unlock()
@@ -158,6 +160,8 @@ func (am *AddressManager) MarkConnectionFailure(address *appmessage.NetAddress) 
 	return am.store.updateNotBanned(key, entry)
 }
 
+// MarkConnectionSuccess notifies the address manager that the given address
+// has successfully connected
 func (am *AddressManager) MarkConnectionSuccess(address *appmessage.NetAddress) error {
 	am.mutex.Lock()
 	defer am.mutex.Unlock()

--- a/infrastructure/network/addressmanager/addressmanager.go
+++ b/infrastructure/network/addressmanager/addressmanager.go
@@ -97,7 +97,7 @@ func (am *AddressManager) addAddressNoLock(netAddress *appmessage.NetAddress) er
 	if am.store.notBannedCount() > maxAddresses {
 		allAddresses := am.store.getAllNotBanned()
 		sort.Slice(allAddresses, func(i, j int) bool {
-			return allAddresses[i].connectionFailedCount < allAddresses[j].connectionFailedCount
+			return allAddresses[i].connectionFailedCount > allAddresses[j].connectionFailedCount
 		})
 
 		toRemove := allAddresses[0]

--- a/infrastructure/network/addressmanager/addressmanager.go
+++ b/infrastructure/network/addressmanager/addressmanager.go
@@ -137,6 +137,19 @@ func (am *AddressManager) RemoveAddress(address *appmessage.NetAddress) error {
 	return am.removeAddressNoLock(address)
 }
 
+func (am *AddressManager) MarkConnectionFailure(address *appmessage.NetAddress) error {
+	am.mutex.Lock()
+	defer am.mutex.Unlock()
+
+	key := netAddressKey(address)
+	entry, ok := am.store.getNotBanned(key)
+	if !ok {
+		return errors.Errorf("address %s is not registered with the address manager", address)
+	}
+	entry.connectionFailedCount = entry.connectionFailedCount + 1
+	return am.store.updateNotBanned(key, entry)
+}
+
 // Addresses returns all addresses
 func (am *AddressManager) Addresses() []*appmessage.NetAddress {
 	am.mutex.Lock()

--- a/infrastructure/network/addressmanager/addressmanager.go
+++ b/infrastructure/network/addressmanager/addressmanager.go
@@ -150,6 +150,19 @@ func (am *AddressManager) MarkConnectionFailure(address *appmessage.NetAddress) 
 	return am.store.updateNotBanned(key, entry)
 }
 
+func (am *AddressManager) MarkConnectionSuccess(address *appmessage.NetAddress) error {
+	am.mutex.Lock()
+	defer am.mutex.Unlock()
+
+	key := netAddressKey(address)
+	entry, ok := am.store.getNotBanned(key)
+	if !ok {
+		return errors.Errorf("address %s is not registered with the address manager", address)
+	}
+	entry.connectionFailedCount = 0
+	return am.store.updateNotBanned(key, entry)
+}
+
 // Addresses returns all addresses
 func (am *AddressManager) Addresses() []*appmessage.NetAddress {
 	am.mutex.Lock()

--- a/infrastructure/network/addressmanager/addressmanager_test.go
+++ b/infrastructure/network/addressmanager/addressmanager_test.go
@@ -351,7 +351,7 @@ func TestOverfillAddressManager(t *testing.T) {
 		t.Fatalf("MarkConnectionFailure: %s", err)
 	}
 
-	// Add one more addresses to the address manager
+	// Add one more address to the address manager
 	err = addressManager.AddAddress(&appmessage.NetAddress{IP: net.IP{7, 8, 0, 0}, Timestamp: mstime.Now()})
 	if err != nil {
 		t.Fatalf("AddAddress: %s", err)

--- a/infrastructure/network/addressmanager/addressmanager_test.go
+++ b/infrastructure/network/addressmanager/addressmanager_test.go
@@ -366,7 +366,7 @@ func TestOverfillAddressManager(t *testing.T) {
 	// Make sure that the first address is no longer in the
 	// connection manager
 	for _, address := range returnedAddresses {
-		if address == testAddress {
+		if address.IP.Equal(testAddress.IP) {
 			t.Fatalf("Unexpectedly found testAddress returned addresses")
 		}
 	}

--- a/infrastructure/network/addressmanager/store.go
+++ b/infrastructure/network/addressmanager/store.go
@@ -86,6 +86,22 @@ func (as *addressStore) restoreBannedAddresses() error {
 	return nil
 }
 
+func (as *addressStore) notBannedCount() int {
+	return len(as.notBannedAddresses)
+}
+
+func (as *addressStore) removeRandom() error {
+	if as.notBannedCount() == 0 {
+		return nil
+	}
+
+	var randomKey addressKey
+	for key := range as.notBannedAddresses {
+		randomKey = key
+	}
+	return as.remove(randomKey)
+}
+
 func (as *addressStore) add(key addressKey, address *appmessage.NetAddress) error {
 	if _, ok := as.notBannedAddresses[key]; ok {
 		return nil

--- a/infrastructure/network/addressmanager/store.go
+++ b/infrastructure/network/addressmanager/store.go
@@ -13,15 +13,15 @@ var bannedAddressBucket = database.MakeBucket([]byte("banned-addresses"))
 
 type addressStore struct {
 	database           database.Database
-	notBannedAddresses map[addressKey]*appmessage.NetAddress
-	bannedAddresses    map[ipv6]*appmessage.NetAddress
+	notBannedAddresses map[addressKey]*address
+	bannedAddresses    map[ipv6]*address
 }
 
 func newAddressStore(database database.Database) (*addressStore, error) {
 	addressStore := &addressStore{
 		database:           database,
-		notBannedAddresses: map[addressKey]*appmessage.NetAddress{},
-		bannedAddresses:    map[ipv6]*appmessage.NetAddress{},
+		notBannedAddresses: map[addressKey]*address{},
+		bannedAddresses:    map[ipv6]*address{},
 	}
 	err := addressStore.restoreNotBannedAddresses()
 	if err != nil {
@@ -56,7 +56,7 @@ func (as *addressStore) restoreNotBannedAddresses() error {
 		if err != nil {
 			return err
 		}
-		netAddress := as.deserializeNetAddress(serializedNetAddress)
+		netAddress := as.deserializeAddress(serializedNetAddress)
 		as.notBannedAddresses[key] = netAddress
 	}
 	return nil
@@ -80,7 +80,7 @@ func (as *addressStore) restoreBannedAddresses() error {
 		if err != nil {
 			return err
 		}
-		netAddress := as.deserializeNetAddress(serializedNetAddress)
+		netAddress := as.deserializeAddress(serializedNetAddress)
 		as.bannedAddresses[ipv6] = netAddress
 	}
 	return nil
@@ -102,7 +102,7 @@ func (as *addressStore) removeRandom() error {
 	return as.remove(randomKey)
 }
 
-func (as *addressStore) add(key addressKey, address *appmessage.NetAddress) error {
+func (as *addressStore) add(key addressKey, address *address) error {
 	if _, ok := as.notBannedAddresses[key]; ok {
 		return nil
 	}
@@ -110,7 +110,7 @@ func (as *addressStore) add(key addressKey, address *appmessage.NetAddress) erro
 	as.notBannedAddresses[key] = address
 
 	databaseKey := as.notBannedDatabaseKey(key)
-	serializedAddress := as.serializeNetAddress(address)
+	serializedAddress := as.serializeAddress(address)
 	return as.database.Put(databaseKey, serializedAddress)
 }
 
@@ -124,18 +124,26 @@ func (as *addressStore) remove(key addressKey) error {
 func (as *addressStore) getAllNotBanned() []*appmessage.NetAddress {
 	addresses := make([]*appmessage.NetAddress, 0, len(as.notBannedAddresses))
 	for _, address := range as.notBannedAddresses {
-		addresses = append(addresses, address)
+		addresses = append(addresses, address.netAddress)
 	}
 	return addresses
 }
 
-func (as *addressStore) getAllNotBannedWithout(ignoredAddresses []*appmessage.NetAddress) []*appmessage.NetAddress {
+func (as *addressStore) getAllNotBannedNetAddresses() []*appmessage.NetAddress {
+	addresses := make([]*appmessage.NetAddress, 0, len(as.notBannedAddresses))
+	for _, address := range as.notBannedAddresses {
+		addresses = append(addresses, address.netAddress)
+	}
+	return addresses
+}
+
+func (as *addressStore) getAllNotBannedNetAddressesWithout(ignoredAddresses []*appmessage.NetAddress) []*appmessage.NetAddress {
 	ignoredKeys := netAddressesKeys(ignoredAddresses)
 
 	addresses := make([]*appmessage.NetAddress, 0, len(as.notBannedAddresses))
 	for key, address := range as.notBannedAddresses {
 		if !ignoredKeys[key] {
-			addresses = append(addresses, address)
+			addresses = append(addresses, address.netAddress)
 		}
 	}
 	return addresses
@@ -146,7 +154,7 @@ func (as *addressStore) isNotBanned(key addressKey) bool {
 	return ok
 }
 
-func (as *addressStore) addBanned(key addressKey, address *appmessage.NetAddress) error {
+func (as *addressStore) addBanned(key addressKey, address *address) error {
 	if _, ok := as.bannedAddresses[key.address]; ok {
 		return nil
 	}
@@ -154,7 +162,7 @@ func (as *addressStore) addBanned(key addressKey, address *appmessage.NetAddress
 	as.bannedAddresses[key.address] = address
 
 	databaseKey := as.bannedDatabaseKey(key)
-	serializedAddress := as.serializeNetAddress(address)
+	serializedAddress := as.serializeAddress(address)
 	return as.database.Put(databaseKey, serializedAddress)
 }
 
@@ -165,10 +173,10 @@ func (as *addressStore) removeBanned(key addressKey) error {
 	return as.database.Delete(databaseKey)
 }
 
-func (as *addressStore) getAllBanned() []*appmessage.NetAddress {
+func (as *addressStore) getAllBannedNetAddresses() []*appmessage.NetAddress {
 	bannedAddresses := make([]*appmessage.NetAddress, 0, len(as.bannedAddresses))
 	for _, bannedAddress := range as.bannedAddresses {
-		bannedAddresses = append(bannedAddresses, bannedAddress)
+		bannedAddresses = append(bannedAddresses, bannedAddress.netAddress)
 	}
 	return bannedAddresses
 }
@@ -178,9 +186,19 @@ func (as *addressStore) isBanned(key addressKey) bool {
 	return ok
 }
 
-func (as *addressStore) getBanned(key addressKey) (*appmessage.NetAddress, bool) {
+func (as *addressStore) getBanned(key addressKey) (*address, bool) {
 	bannedAddress, ok := as.bannedAddresses[key.address]
 	return bannedAddress, ok
+}
+
+// netAddressKeys returns a key of the ip address to use it in maps.
+func netAddressesKeys(netAddresses []*appmessage.NetAddress) map[addressKey]bool {
+	result := make(map[addressKey]bool, len(netAddresses))
+	for _, netAddress := range netAddresses {
+		key := netAddressKey(netAddress)
+		result[key] = true
+	}
+	return result
 }
 
 func (as *addressStore) notBannedDatabaseKey(key addressKey) *database.Key {
@@ -214,27 +232,32 @@ func (as *addressStore) deserializeAddressKey(serializedKey []byte) addressKey {
 	}
 }
 
-func (as *addressStore) serializeNetAddress(netAddress *appmessage.NetAddress) []byte {
-	serializedSize := 16 + 2 + 8 // ipv6 + port + timestamp
+func (as *addressStore) serializeAddress(address *address) []byte {
+	serializedSize := 16 + 2 + 8 + 8 // ipv6 + port + timestamp + connectionFailedCount
 	serializedNetAddress := make([]byte, serializedSize)
 
-	copy(serializedNetAddress[:], netAddress.IP[:])
-	binary.LittleEndian.PutUint16(serializedNetAddress[16:], netAddress.Port)
-	binary.LittleEndian.PutUint64(serializedNetAddress[18:], uint64(netAddress.Timestamp.UnixMilliseconds()))
+	copy(serializedNetAddress[:], address.netAddress.IP[:])
+	binary.LittleEndian.PutUint16(serializedNetAddress[16:], address.netAddress.Port)
+	binary.LittleEndian.PutUint64(serializedNetAddress[18:], uint64(address.netAddress.Timestamp.UnixMilliseconds()))
+	binary.LittleEndian.PutUint64(serializedNetAddress[26:], uint64(address.connectionFailedCount))
 
 	return serializedNetAddress
 }
 
-func (as *addressStore) deserializeNetAddress(serializedNetAddress []byte) *appmessage.NetAddress {
+func (as *addressStore) deserializeAddress(serializedAddress []byte) *address {
 	ip := make(net.IP, 16)
-	copy(ip[:], serializedNetAddress[:])
+	copy(ip[:], serializedAddress[:])
 
-	port := binary.LittleEndian.Uint16(serializedNetAddress[16:])
-	timestamp := mstime.UnixMilliseconds(int64(binary.LittleEndian.Uint64(serializedNetAddress[18:])))
+	port := binary.LittleEndian.Uint16(serializedAddress[16:])
+	timestamp := mstime.UnixMilliseconds(int64(binary.LittleEndian.Uint64(serializedAddress[18:])))
+	connectionFailedCount := binary.LittleEndian.Uint64(serializedAddress[26:])
 
-	return &appmessage.NetAddress{
-		IP:        ip,
-		Port:      port,
-		Timestamp: timestamp,
+	return &address{
+		netAddress: &appmessage.NetAddress{
+			IP:        ip,
+			Port:      port,
+			Timestamp: timestamp,
+		},
+		connectionFailedCount: connectionFailedCount,
 	}
 }

--- a/infrastructure/network/addressmanager/store.go
+++ b/infrastructure/network/addressmanager/store.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/kaspanet/kaspad/infrastructure/db/database"
 	"github.com/kaspanet/kaspad/util/mstime"
+	"github.com/pkg/errors"
 	"net"
 )
 
@@ -112,6 +113,23 @@ func (as *addressStore) add(key addressKey, address *address) error {
 	databaseKey := as.notBannedDatabaseKey(key)
 	serializedAddress := as.serializeAddress(address)
 	return as.database.Put(databaseKey, serializedAddress)
+}
+
+func (as *addressStore) updateNotBanned(key addressKey, address *address) error {
+	if _, ok := as.notBannedAddresses[key]; !ok {
+		return errors.Errorf("address %s is not in the store", address.netAddress)
+	}
+
+	as.notBannedAddresses[key] = address
+
+	databaseKey := as.notBannedDatabaseKey(key)
+	serializedAddress := as.serializeAddress(address)
+	return as.database.Put(databaseKey, serializedAddress)
+}
+
+func (as *addressStore) getNotBanned(key addressKey) (*address, bool) {
+	address, ok := as.notBannedAddresses[key]
+	return address, ok
 }
 
 func (as *addressStore) remove(key addressKey) error {

--- a/infrastructure/network/addressmanager/store.go
+++ b/infrastructure/network/addressmanager/store.go
@@ -91,18 +91,6 @@ func (as *addressStore) notBannedCount() int {
 	return len(as.notBannedAddresses)
 }
 
-func (as *addressStore) removeRandom() error {
-	if as.notBannedCount() == 0 {
-		return nil
-	}
-
-	var randomKey addressKey
-	for key := range as.notBannedAddresses {
-		randomKey = key
-	}
-	return as.remove(randomKey)
-}
-
 func (as *addressStore) add(key addressKey, address *address) error {
 	if _, ok := as.notBannedAddresses[key]; ok {
 		return nil
@@ -117,7 +105,7 @@ func (as *addressStore) add(key addressKey, address *address) error {
 
 func (as *addressStore) updateNotBanned(key addressKey, address *address) error {
 	if _, ok := as.notBannedAddresses[key]; !ok {
-		return errors.Errorf("address %s is not in the store", address.netAddress)
+		return errors.Errorf("address %s is not in the store", address.netAddress.TCPAddress())
 	}
 
 	as.notBannedAddresses[key] = address
@@ -139,10 +127,10 @@ func (as *addressStore) remove(key addressKey) error {
 	return as.database.Delete(databaseKey)
 }
 
-func (as *addressStore) getAllNotBanned() []*appmessage.NetAddress {
-	addresses := make([]*appmessage.NetAddress, 0, len(as.notBannedAddresses))
+func (as *addressStore) getAllNotBanned() []*address {
+	addresses := make([]*address, 0, len(as.notBannedAddresses))
 	for _, address := range as.notBannedAddresses {
-		addresses = append(addresses, address.netAddress)
+		addresses = append(addresses, address)
 	}
 	return addresses
 }

--- a/infrastructure/network/addressmanager/store.go
+++ b/infrastructure/network/addressmanager/store.go
@@ -103,6 +103,7 @@ func (as *addressStore) add(key addressKey, address *address) error {
 	return as.database.Put(databaseKey, serializedAddress)
 }
 
+// updateNotBanned updates the not-banned address collection
 func (as *addressStore) updateNotBanned(key addressKey, address *address) error {
 	if _, ok := as.notBannedAddresses[key]; !ok {
 		return errors.Errorf("address %s is not in the store", address.netAddress.TCPAddress())

--- a/infrastructure/network/addressmanager/store_test.go
+++ b/infrastructure/network/addressmanager/store_test.go
@@ -24,21 +24,24 @@ func TestAddressKeySerialization(t *testing.T) {
 	}
 }
 
-func TestNetAddressSerialization(t *testing.T) {
-	addressManager, teardown := newAddressManagerForTest(t, "TestNetAddressSerialization")
+func TestAddressSerialization(t *testing.T) {
+	addressManager, teardown := newAddressManagerForTest(t, "TestAddressSerialization")
 	defer teardown()
 	addressStore := addressManager.store
 
-	testAddress := &appmessage.NetAddress{
-		IP:        net.ParseIP("2602:100:abcd::102"),
-		Port:      12345,
-		Timestamp: mstime.Now(),
+	testAddress := &address{
+		netAddress: &appmessage.NetAddress{
+			IP:        net.ParseIP("2602:100:abcd::102"),
+			Port:      12345,
+			Timestamp: mstime.Now(),
+		},
+		connectionFailedCount: 98465,
 	}
 
-	serializedTestNetAddress := addressStore.serializeNetAddress(testAddress)
-	deserializedTestNetAddress := addressStore.deserializeNetAddress(serializedTestNetAddress)
-	if !reflect.DeepEqual(testAddress, deserializedTestNetAddress) {
-		t.Fatalf("testAddress and deserializedTestNetAddress are not equal\n"+
-			"testAddress:%+v\ndeserializedTestNetAddress:%+v", testAddress, deserializedTestNetAddress)
+	serializedTestAddress := addressStore.serializeAddress(testAddress)
+	deserializedTestAddress := addressStore.deserializeAddress(serializedTestAddress)
+	if !reflect.DeepEqual(testAddress, deserializedTestAddress) {
+		t.Fatalf("testAddress and deserializedTestAddress are not equal\n"+
+			"testAddress:%+v\ndeserializedTestAddress:%+v", testAddress, deserializedTestAddress)
 	}
 }

--- a/infrastructure/network/connmanager/outgoing_connections.go
+++ b/infrastructure/network/connmanager/outgoing_connections.go
@@ -42,7 +42,6 @@ func (c *ConnectionManager) checkOutgoingConnections(connSet connectionSet) {
 		err := c.initiateConnection(addressString)
 		if err != nil {
 			log.Infof("Couldn't connect to %s: %s", addressString, err)
-			c.addressManager.RemoveAddress(netAddress)
 			continue
 		}
 

--- a/infrastructure/network/connmanager/outgoing_connections.go
+++ b/infrastructure/network/connmanager/outgoing_connections.go
@@ -42,6 +42,7 @@ func (c *ConnectionManager) checkOutgoingConnections(connSet connectionSet) {
 		err := c.initiateConnection(addressString)
 		if err != nil {
 			log.Infof("Couldn't connect to %s: %s", addressString, err)
+			c.addressManager.MarkConnectionFailure(netAddress)
 			continue
 		}
 

--- a/infrastructure/network/connmanager/outgoing_connections.go
+++ b/infrastructure/network/connmanager/outgoing_connections.go
@@ -45,6 +45,7 @@ func (c *ConnectionManager) checkOutgoingConnections(connSet connectionSet) {
 			c.addressManager.MarkConnectionFailure(netAddress)
 			continue
 		}
+		c.addressManager.MarkConnectionSuccess(netAddress)
 
 		c.activeOutgoing[addressString] = struct{}{}
 	}


### PR DESCRIPTION
This implements https://github.com/kaspanet/kaspad/issues/1472

This ticket makes the following changes:
* Adds a limit to the address manager
* Once the limit is reached, evict the address that failed to connect the most