### PR TITLE
Batch transaction inv messages

### DIFF
--- a/app/protocol/flowcontext/blocks.go
+++ b/app/protocol/flowcontext/blocks.go
@@ -95,15 +95,7 @@ func (f *FlowContext) broadcastTransactionsAfterBlockAdded(
 	for i, txID := range txIDsToRebroadcast {
 		txIDsToBroadcast[offset+i] = txID
 	}
-
-	if len(txIDsToBroadcast) == 0 {
-		return nil
-	}
-	if len(txIDsToBroadcast) > appmessage.MaxInvPerTxInvMsg {
-		txIDsToBroadcast = txIDsToBroadcast[:appmessage.MaxInvPerTxInvMsg]
-	}
-	inv := appmessage.NewMsgInvTransaction(txIDsToBroadcast)
-	return f.Broadcast(inv)
+	return f.EnqueueTransactionIDsForPropagation(txIDsToBroadcast)
 }
 
 // SharedRequestedBlocks returns a *blockrelay.SharedRequestedBlocks for sharing

--- a/app/protocol/flowcontext/transactions.go
+++ b/app/protocol/flowcontext/transactions.go
@@ -9,6 +9,9 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/utils/consensushashing"
 )
 
+// TransactionIDPropagationInterval is the interval between transaction IDs propagations
+const TransactionIDPropagationInterval = 10 * time.Second
+
 // AddTransaction adds transaction to the mempool and propagates it.
 func (f *FlowContext) AddTransaction(tx *externalapi.DomainTransaction, allowOrphan bool) error {
 	acceptedTransactions, err := f.Domain().MiningManager().ValidateAndInsertTransaction(tx, true, allowOrphan)
@@ -52,8 +55,7 @@ func (f *FlowContext) EnqueueTransactionIDsForPropagation(transactionIDs []*exte
 
 	f.transactionIDsToPropagate = append(f.transactionIDsToPropagate, transactionIDs...)
 
-	const propagationInterval = 10 * time.Second
-	if time.Since(f.lastTransactionIDPropagationTime) < propagationInterval &&
+	if time.Since(f.lastTransactionIDPropagationTime) < TransactionIDPropagationInterval &&
 		len(f.transactionIDsToPropagate) < appmessage.MaxInvPerTxInvMsg {
 		return nil
 	}

--- a/app/protocol/flowcontext/transactions.go
+++ b/app/protocol/flowcontext/transactions.go
@@ -66,6 +66,8 @@ func (f *FlowContext) EnqueueTransactionIDsForPropagation(transactionIDs []*exte
 		transactionIDsToBroadcast = transactionIDsToBroadcast[:appmessage.MaxInvPerTxInvMsg]
 	}
 
+	log.Infof("Transaction propagation: broadcasting %d transactions", len(transactionIDsToBroadcast))
+
 	inv := appmessage.NewMsgInvTransaction(transactionIDsToBroadcast)
 	err := f.Broadcast(inv)
 	if err != nil {

--- a/app/protocol/flowcontext/transactions.go
+++ b/app/protocol/flowcontext/transactions.go
@@ -64,7 +64,6 @@ func (f *FlowContext) EnqueueTransactionIDsForPropagation(transactionIDs []*exte
 		transactionIDsToBroadcast = transactionIDsToBroadcast[:appmessage.MaxInvPerTxInvMsg]
 	}
 
-	log.Infof("EnqueueTransactionIDsForPropagation %s", transactionIDs)
 	inv := appmessage.NewMsgInvTransaction(transactionIDsToBroadcast)
 	err := f.Broadcast(inv)
 	if err != nil {

--- a/app/protocol/flows/transactionrelay/handle_relayed_transactions.go
+++ b/app/protocol/flows/transactionrelay/handle_relayed_transactions.go
@@ -19,8 +19,8 @@ type TransactionsRelayContext interface {
 	NetAdapter() *netadapter.NetAdapter
 	Domain() domain.Domain
 	SharedRequestedTransactions() *SharedRequestedTransactions
-	Broadcast(message appmessage.Message) error
 	OnTransactionAddedToMempool()
+	EnqueueTransactionIDsForPropagation(transactionIDs []*externalapi.DomainTransactionID) error
 }
 
 type handleRelayedTransactionsFlow struct {
@@ -119,8 +119,7 @@ func (flow *handleRelayedTransactionsFlow) readInv() (*appmessage.MsgInvTransact
 }
 
 func (flow *handleRelayedTransactionsFlow) broadcastAcceptedTransactions(acceptedTxIDs []*externalapi.DomainTransactionID) error {
-	inv := appmessage.NewMsgInvTransaction(acceptedTxIDs)
-	return flow.Broadcast(inv)
+	return flow.EnqueueTransactionIDsForPropagation(acceptedTxIDs)
 }
 
 // readMsgTxOrNotFound returns the next msgTx or msgTransactionNotFound in incomingRoute,

--- a/app/protocol/flows/transactionrelay/handle_relayed_transactions_test.go
+++ b/app/protocol/flows/transactionrelay/handle_relayed_transactions_test.go
@@ -39,7 +39,7 @@ func (m *mocTransactionsRelayContext) SharedRequestedTransactions() *transaction
 	return m.sharedRequestedTransactions
 }
 
-func (m *mocTransactionsRelayContext) Broadcast(appmessage.Message) error {
+func (m *mocTransactionsRelayContext) EnqueueTransactionIDsForPropagation(transactionIDs []*externalapi.DomainTransactionID) error {
 	return nil
 }
 

--- a/testing/integration/tx_relay_test.go
+++ b/testing/integration/tx_relay_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"encoding/hex"
+	"github.com/kaspanet/kaspad/app/protocol/flowcontext"
 	"strings"
 	"testing"
 	"time"
@@ -43,6 +44,10 @@ func TestTxRelay(t *testing.T) {
 		mineNextBlock(t, payer)
 		waitForPayeeToReceiveBlock(t, payeeBlockAddedChan)
 	}
+
+	// Sleep for `TransactionIDPropagationInterval` to make sure that our transaction will
+	// be propagated
+	time.Sleep(flowcontext.TransactionIDPropagationInterval)
 
 	msgTx := generateTx(t, secondBlock.Transactions[transactionhelper.CoinbaseTransactionIndex], payer, payee)
 	domainTransaction := appmessage.MsgTxToDomainTransaction(msgTx)


### PR DESCRIPTION
On a network with five nodes and 20 transactions per second, this PR reduces the amount of transaction inv messages that any of the nodes receives from ~5000 per minute to ~30.

Besides the obvious performance implications, this also fixes https://github.com/kaspanet/kaspad/issues/1377