### PR TITLE
Validate locktime when admitted into mempool and when building a block.

### DIFF
--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -92,6 +92,11 @@ func (s *consensus) ValidateTransactionAndPopulateWithConsensusData(transaction 
 		return err
 	}
 
+	err = s.transactionValidator.ValidateTransactionWithContextAndWithoutUTXOContext(stagingArea, transaction, model.VirtualBlockHash)
+	if err != nil {
+		return err
+	}
+
 	return s.transactionValidator.ValidateTransactionInContextAndPopulateMassAndFee(
 		stagingArea, transaction, model.VirtualBlockHash, virtualSelectedParentMedianTime)
 }

--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -92,7 +92,7 @@ func (s *consensus) ValidateTransactionAndPopulateWithConsensusData(transaction 
 		return err
 	}
 
-	err = s.transactionValidator.ValidateTransactionWithContextAndWithoutUTXOContext(stagingArea, transaction, model.VirtualBlockHash)
+	err = s.transactionValidator.ValidateTransactionInContextIgnoringUTXO(stagingArea, transaction, model.VirtualBlockHash)
 	if err != nil {
 		return err
 	}

--- a/domain/consensus/model/interface_processes_transactionvalidator.go
+++ b/domain/consensus/model/interface_processes_transactionvalidator.go
@@ -8,6 +8,8 @@ import (
 // it's possible to determine whether a transaction is valid
 type TransactionValidator interface {
 	ValidateTransactionInIsolation(transaction *externalapi.DomainTransaction) error
+	ValidateTransactionWithContextAndWithoutUTXOContext(stagingArea *StagingArea, tx *externalapi.DomainTransaction,
+		povBlockHash *externalapi.DomainHash) error
 	ValidateTransactionInContextAndPopulateMassAndFee(stagingArea *StagingArea,
 		tx *externalapi.DomainTransaction, povBlockHash *externalapi.DomainHash, selectedParentMedianTime int64) error
 }

--- a/domain/consensus/model/interface_processes_transactionvalidator.go
+++ b/domain/consensus/model/interface_processes_transactionvalidator.go
@@ -8,7 +8,7 @@ import (
 // it's possible to determine whether a transaction is valid
 type TransactionValidator interface {
 	ValidateTransactionInIsolation(transaction *externalapi.DomainTransaction) error
-	ValidateTransactionWithContextAndWithoutUTXOContext(stagingArea *StagingArea, tx *externalapi.DomainTransaction,
+	ValidateTransactionInContextIgnoringUTXO(stagingArea *StagingArea, tx *externalapi.DomainTransaction,
 		povBlockHash *externalapi.DomainHash) error
 	ValidateTransactionInContextAndPopulateMassAndFee(stagingArea *StagingArea,
 		tx *externalapi.DomainTransaction, povBlockHash *externalapi.DomainHash, selectedParentMedianTime int64) error

--- a/domain/consensus/processes/blockbuilder/block_builder.go
+++ b/domain/consensus/processes/blockbuilder/block_builder.go
@@ -145,6 +145,11 @@ func (bb *blockBuilder) validateTransaction(
 		return err
 	}
 
+	err = bb.transactionValidator.ValidateTransactionWithContextAndWithoutUTXOContext(stagingArea, transaction, model.VirtualBlockHash)
+	if err != nil {
+		return err
+	}
+
 	virtualSelectedParentMedianTime, err := bb.pastMedianTimeManager.PastMedianTime(stagingArea, model.VirtualBlockHash)
 	if err != nil {
 		return err

--- a/domain/consensus/processes/blockbuilder/block_builder.go
+++ b/domain/consensus/processes/blockbuilder/block_builder.go
@@ -145,7 +145,7 @@ func (bb *blockBuilder) validateTransaction(
 		return err
 	}
 
-	err = bb.transactionValidator.ValidateTransactionWithContextAndWithoutUTXOContext(stagingArea, transaction, model.VirtualBlockHash)
+	err = bb.transactionValidator.ValidateTransactionInContextIgnoringUTXO(stagingArea, transaction, model.VirtualBlockHash)
 	if err != nil {
 		return err
 	}

--- a/domain/consensus/processes/blockvalidator/block_body_in_context.go
+++ b/domain/consensus/processes/blockvalidator/block_body_in_context.go
@@ -123,7 +123,7 @@ func (v *blockValidator) checkBlockTransactions(
 
 	// Ensure all transactions in the block are finalized.
 	for _, tx := range block.Transactions {
-		if err = v.transactionValidator.ValidateTransactionWithContextAndWithoutUTXOContext(stagingArea, tx, blockHash); err != nil {
+		if err = v.transactionValidator.ValidateTransactionInContextIgnoringUTXO(stagingArea, tx, blockHash); err != nil {
 			return err
 		}
 	}

--- a/domain/consensus/processes/blockvalidator/block_body_in_context_test.go
+++ b/domain/consensus/processes/blockvalidator/block_body_in_context_test.go
@@ -187,9 +187,10 @@ func TestIsFinalizedTransaction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error Inserting block: %+v", err)
 		}
-		blockGhostDAG, err := tc.GHOSTDAGDataStore().Get(tc.DatabaseContext(), stagingArea, consensushashing.BlockHash(block))
+		blockHash := consensushashing.BlockHash(block)
+		blockDAAScore, err := tc.DAABlocksStore().DAAScore(tc.DatabaseContext(), stagingArea, blockHash)
 		if err != nil {
-			t.Fatalf("Error getting GhostDAG Data: %+v", err)
+			t.Fatalf("Error getting block DAA score : %+v", err)
 		}
 		blockParents := block.Header.ParentHashes()
 		parentToSpend, err := tc.GetBlock(blockParents[0])
@@ -212,10 +213,10 @@ func TestIsFinalizedTransaction(t *testing.T) {
 			}
 		}
 
-		// Check that the same blueScore or higher fails, but lower passes.
-		checkForLockTimeAndSequence(blockGhostDAG.BlueScore()+1, 0, false)
-		checkForLockTimeAndSequence(blockGhostDAG.BlueScore(), 0, false)
-		checkForLockTimeAndSequence(blockGhostDAG.BlueScore()-1, 0, true)
+		// Check that the same DAAScore or higher fails, but lower passes.
+		checkForLockTimeAndSequence(blockDAAScore+1, 0, false)
+		checkForLockTimeAndSequence(blockDAAScore, 0, false)
+		checkForLockTimeAndSequence(blockDAAScore-1, 0, true)
 
 		pastMedianTime, err := tc.PastMedianTimeManager().PastMedianTime(stagingArea, consensushashing.BlockHash(block))
 		if err != nil {

--- a/domain/consensus/processes/transactionvalidator/transaction_in_context.go
+++ b/domain/consensus/processes/transactionvalidator/transaction_in_context.go
@@ -46,8 +46,8 @@ func (v *transactionValidator) IsFinalizedTransaction(tx *externalapi.DomainTran
 	return true
 }
 
-// ValidateTransactionWithContextAndWithoutUTXOContext validates the transaction with context and without the context of UTXO
-func (v *transactionValidator) ValidateTransactionWithContextAndWithoutUTXOContext(stagingArea *model.StagingArea, tx *externalapi.DomainTransaction,
+// ValidateTransactionInContextIgnoringUTXO validates the transaction with consensus context but ignoring UTXO
+func (v *transactionValidator) ValidateTransactionInContextIgnoringUTXO(stagingArea *model.StagingArea, tx *externalapi.DomainTransaction,
 	povBlockHash *externalapi.DomainHash) error {
 
 	povBlockDAAScore, err := v.daaBlocksStore.DAAScore(v.databaseContext, stagingArea, povBlockHash)

--- a/domain/consensus/timelock_CLTV_test.go
+++ b/domain/consensus/timelock_CLTV_test.go
@@ -2,6 +2,8 @@ package consensus_test
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/kaspanet/kaspad/domain/consensus"
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
@@ -11,7 +13,6 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/utils/testutils"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/transactionhelper"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/txscript"
-	"testing"
 )
 
 // TestCheckLockTimeVerifyConditionedByDAAScore verifies that an output locked by the CLTV script is spendable only after


### PR DESCRIPTION
#1721  
Validate locktime when admitted into mempool and when building a block.
Also, fix isFinalizedTransaction to use DAAscore instead of blue score.