### PR TITLE
Cache the miner state

### DIFF
--- a/cmd/kaspaminer/mineloop.go
+++ b/cmd/kaspaminer/mineloop.go
@@ -155,7 +155,7 @@ func mineNextBlock(mineWhenNotSynced bool) *externalapi.DomainBlock {
 	}
 }
 
-func getBlockForMining(mineWhenNotSynced bool) (*externalapi.DomainBlock, *pow.MinerState) {
+func getBlockForMining(mineWhenNotSynced bool) (*externalapi.DomainBlock, *pow.State) {
 	tryCount := 0
 
 	const sleepTime = 500 * time.Millisecond

--- a/cmd/kaspaminer/templatemanager/templatemanager.go
+++ b/cmd/kaspaminer/templatemanager/templatemanager.go
@@ -3,23 +3,26 @@ package templatemanager
 import (
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"github.com/kaspanet/kaspad/domain/consensus/utils/pow"
 	"sync"
 )
 
 var currentTemplate *externalapi.DomainBlock
+var currentState *pow.MinerState
 var isSynced bool
 var lock = &sync.Mutex{}
 
 // Get returns the template to work on
-func Get() (*externalapi.DomainBlock, bool) {
+func Get() (*externalapi.DomainBlock,*pow.MinerState, bool) {
 	lock.Lock()
 	defer lock.Unlock()
 	// Shallow copy the block so when the user replaces the header it won't affect the template here.
 	if currentTemplate == nil {
-		return nil, false
+		return nil, nil, false
 	}
 	block := *currentTemplate
-	return &block, isSynced
+	state := *currentState
+	return &block, &state, isSynced
 }
 
 // Set sets the current template to work on
@@ -31,6 +34,7 @@ func Set(template *appmessage.GetBlockTemplateResponseMessage) error {
 	lock.Lock()
 	defer lock.Unlock()
 	currentTemplate = block
+	currentState = pow.NewMinerState(block.Header.ToMutable())
 	isSynced = template.IsSynced
 	return nil
 }

--- a/cmd/kaspaminer/templatemanager/templatemanager.go
+++ b/cmd/kaspaminer/templatemanager/templatemanager.go
@@ -8,12 +8,12 @@ import (
 )
 
 var currentTemplate *externalapi.DomainBlock
-var currentState *pow.MinerState
+var currentState *pow.State
 var isSynced bool
 var lock = &sync.Mutex{}
 
 // Get returns the template to work on
-func Get() (*externalapi.DomainBlock,*pow.MinerState, bool) {
+func Get() (*externalapi.DomainBlock, *pow.State, bool) {
 	lock.Lock()
 	defer lock.Unlock()
 	// Shallow copy the block so when the user replaces the header it won't affect the template here.
@@ -34,7 +34,7 @@ func Set(template *appmessage.GetBlockTemplateResponseMessage) error {
 	lock.Lock()
 	defer lock.Unlock()
 	currentTemplate = block
-	currentState = pow.NewMinerState(block.Header.ToMutable())
+	currentState = pow.NewState(block.Header.ToMutable())
 	isSynced = template.IsSynced
 	return nil
 }

--- a/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty.go
+++ b/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty.go
@@ -148,7 +148,7 @@ func (v *blockValidator) validateDifficulty(stagingArea *model.StagingArea,
 //    difficulty is not performed.
 func (v *blockValidator) checkProofOfWork(header externalapi.BlockHeader) error {
 	// The target difficulty must be larger than zero.
-	state := pow.NewMinerState(header.ToMutable())
+	state := pow.NewState(header.ToMutable())
 	target := &state.Target
 	if target.Sign() <= 0 {
 		return errors.Wrapf(ruleerrors.ErrNegativeTarget, "block target difficulty of %064x is too low",

--- a/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty.go
+++ b/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/utils/virtual"
 	"github.com/kaspanet/kaspad/infrastructure/db/database"
 	"github.com/kaspanet/kaspad/infrastructure/logger"
-	"github.com/kaspanet/kaspad/util/difficulty"
 	"github.com/pkg/errors"
 )
 
@@ -149,7 +148,8 @@ func (v *blockValidator) validateDifficulty(stagingArea *model.StagingArea,
 //    difficulty is not performed.
 func (v *blockValidator) checkProofOfWork(header externalapi.BlockHeader) error {
 	// The target difficulty must be larger than zero.
-	target := difficulty.CompactToBig(header.Bits())
+	state := pow.NewMinerState(header.ToMutable())
+	target := &state.Target
 	if target.Sign() <= 0 {
 		return errors.Wrapf(ruleerrors.ErrNegativeTarget, "block target difficulty of %064x is too low",
 			target)
@@ -163,7 +163,7 @@ func (v *blockValidator) checkProofOfWork(header externalapi.BlockHeader) error 
 
 	// The block pow must be valid unless the flag to avoid proof of work checks is set.
 	if !v.skipPoW {
-		valid := pow.CheckProofOfWorkWithTarget(header.ToMutable(), target)
+		valid := state.CheckProofOfWork()
 		if !valid {
 			return errors.Wrap(ruleerrors.ErrInvalidPoW, "block has invalid proof of work")
 		}

--- a/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty_test.go
+++ b/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty_test.go
@@ -111,13 +111,13 @@ func TestPOW(t *testing.T) {
 
 // solveBlockWithWrongPOW increments the given block's nonce until it gets wrong POW (for test!).
 func solveBlockWithWrongPOW(block *externalapi.DomainBlock) *externalapi.DomainBlock {
-	targetDifficulty := difficulty.CompactToBig(block.Header.Bits())
-	headerForMining := block.Header.ToMutable()
-	initialNonce := uint64(0)
-	for i := initialNonce; i < math.MaxUint64; i++ {
-		headerForMining.SetNonce(i)
-		if !pow.CheckProofOfWorkWithTarget(headerForMining, targetDifficulty) {
-			block.Header = headerForMining.ToImmutable()
+	header := block.Header.ToMutable()
+	state := pow.NewMinerState(header)
+	for i := uint64(0); i < math.MaxUint64; i++ {
+		state.Nonce = i
+		if !state.CheckProofOfWork() {
+			header.SetNonce(state.Nonce)
+			block.Header = header.ToImmutable()
 			return block
 		}
 	}

--- a/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty_test.go
+++ b/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty_test.go
@@ -112,7 +112,7 @@ func TestPOW(t *testing.T) {
 // solveBlockWithWrongPOW increments the given block's nonce until it gets wrong POW (for test!).
 func solveBlockWithWrongPOW(block *externalapi.DomainBlock) *externalapi.DomainBlock {
 	header := block.Header.ToMutable()
-	state := pow.NewMinerState(header)
+	state := pow.NewState(header)
 	for i := uint64(0); i < math.MaxUint64; i++ {
 		state.Nonce = i
 		if !state.CheckProofOfWork() {

--- a/domain/consensus/utils/mining/solve.go
+++ b/domain/consensus/utils/mining/solve.go
@@ -12,7 +12,7 @@ import (
 // SolveBlock increments the given block's nonce until it matches the difficulty requirements in its bits field
 func SolveBlock(block *externalapi.DomainBlock, rd *rand.Rand) {
 	header := block.Header.ToMutable()
-	state := pow.NewMinerState(header)
+	state := pow.NewState(header)
 	for state.Nonce = rd.Uint64(); state.Nonce < math.MaxUint64; state.Nonce++ {
 		if state.CheckProofOfWork() {
 			header.SetNonce(state.Nonce)

--- a/domain/consensus/utils/mining/solve.go
+++ b/domain/consensus/utils/mining/solve.go
@@ -6,18 +6,17 @@ import (
 
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/pow"
-	"github.com/kaspanet/kaspad/util/difficulty"
 	"github.com/pkg/errors"
 )
 
 // SolveBlock increments the given block's nonce until it matches the difficulty requirements in its bits field
 func SolveBlock(block *externalapi.DomainBlock, rd *rand.Rand) {
-	targetDifficulty := difficulty.CompactToBig(block.Header.Bits())
-	headerForMining := block.Header.ToMutable()
-	for i := rd.Uint64(); i < math.MaxUint64; i++ {
-		headerForMining.SetNonce(i)
-		if pow.CheckProofOfWorkWithTarget(headerForMining, targetDifficulty) {
-			block.Header = headerForMining.ToImmutable()
+	header := block.Header.ToMutable()
+	state := pow.NewMinerState(header)
+	for state.Nonce = rd.Uint64(); state.Nonce < math.MaxUint64; state.Nonce++ {
+		if state.CheckProofOfWork() {
+			header.SetNonce(state.Nonce)
+			block.Header = header.ToImmutable()
 			return
 		}
 	}

--- a/domain/consensus/utils/pow/pow.go
+++ b/domain/consensus/utils/pow/pow.go
@@ -12,7 +12,7 @@ import (
 	"math/big"
 )
 
-type MinerState struct {
+type State struct {
 	mat        matrix
 	Timestamp  int64
 	Nonce      uint64
@@ -20,9 +20,9 @@ type MinerState struct {
 	prePowHash externalapi.DomainHash
 }
 
-// NewMinerState creates a new miner state with pre-computed values to speed up mining
+// NewState creates a new miner state with pre-computed values to speed up mining
 // It takes the target from the Bits field
-func NewMinerState(header externalapi.MutableBlockHeader) *MinerState {
+func NewState(header externalapi.MutableBlockHeader) *State {
 	target := difficulty.CompactToBig(header.Bits())
 	// Zero out the time and nonce.
 	timestamp, nonce := header.TimeInMilliseconds(), header.Nonce()
@@ -32,7 +32,7 @@ func NewMinerState(header externalapi.MutableBlockHeader) *MinerState {
 	header.SetTimeInMilliseconds(timestamp)
 	header.SetNonce(nonce)
 
-	return &MinerState{
+	return &State{
 		Target:     *target,
 		prePowHash: *prePowHash,
 		mat:        *generateMatrix(prePowHash),
@@ -42,7 +42,7 @@ func NewMinerState(header externalapi.MutableBlockHeader) *MinerState {
 }
 
 // CalculateProofOfWorkValue hashes the internal header and returns its big.Int value
-func (state *MinerState) CalculateProofOfWorkValue() *big.Int {
+func (state *State) CalculateProofOfWorkValue() *big.Int {
 	// PRE_POW_HASH || TIME || 32 zero byte padding || NONCE
 	writer := hashes.NewPoWHashWriter()
 	writer.InfallibleWrite(state.prePowHash.ByteSlice())
@@ -61,14 +61,14 @@ func (state *MinerState) CalculateProofOfWorkValue() *big.Int {
 	return toBig(heavyHash)
 }
 
-// IncrementNonce the nonce in MinerState by 1
-func (state *MinerState) IncrementNonce() {
+// IncrementNonce the nonce in State by 1
+func (state *State) IncrementNonce() {
 	state.Nonce += 1
 }
 
 // CheckProofOfWork check's if the block has a valid PoW according to the provided target
 // it does not check if the difficulty itself is valid or less than the maximum for the appropriate network
-func (state *MinerState) CheckProofOfWork() bool {
+func (state *State) CheckProofOfWork() bool {
 	// The block pow must be less than the claimed target
 	powNum := state.CalculateProofOfWorkValue()
 
@@ -79,7 +79,7 @@ func (state *MinerState) CheckProofOfWork() bool {
 // CheckProofOfWorkByBits check's if the block has a valid PoW according to its Bits field
 // it does not check if the difficulty itself is valid or less than the maximum for the appropriate network
 func CheckProofOfWorkByBits(header externalapi.MutableBlockHeader) bool {
-	return NewMinerState(header).CheckProofOfWork()
+	return NewState(header).CheckProofOfWork()
 }
 
 // ToBig converts a externalapi.DomainHash into a big.Int treated as a little endian string.
@@ -102,7 +102,7 @@ func BlockLevel(header externalapi.BlockHeader) int {
 		return constants.MaxBlockLevel
 	}
 
-	proofOfWorkValue := NewMinerState(header.ToMutable()).CalculateProofOfWorkValue()
+	proofOfWorkValue := NewState(header.ToMutable()).CalculateProofOfWorkValue()
 	for blockLevel := 0; ; blockLevel++ {
 		if blockLevel == constants.MaxBlockLevel || proofOfWorkValue.Bit(blockLevel+1) != 0 {
 			return blockLevel

--- a/domain/consensus/utils/pow/pow.go
+++ b/domain/consensus/utils/pow/pow.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 )
 
+// State is an intermediate data structure with pre-computed values to speed up mining.
 type State struct {
 	mat        matrix
 	Timestamp  int64
@@ -20,7 +21,7 @@ type State struct {
 	prePowHash externalapi.DomainHash
 }
 
-// NewState creates a new miner state with pre-computed values to speed up mining
+// NewState creates a new state with pre-computed values to speed up mining
 // It takes the target from the Bits field
 func NewState(header externalapi.MutableBlockHeader) *State {
 	target := difficulty.CompactToBig(header.Bits())
@@ -63,7 +64,7 @@ func (state *State) CalculateProofOfWorkValue() *big.Int {
 
 // IncrementNonce the nonce in State by 1
 func (state *State) IncrementNonce() {
-	state.Nonce += 1
+	state.Nonce++
 }
 
 // CheckProofOfWork check's if the block has a valid PoW according to the provided target

--- a/stability-tests/daa/daa_test.go
+++ b/stability-tests/daa/daa_test.go
@@ -160,7 +160,7 @@ func measureMachineHashNanoseconds(t *testing.T) int64 {
 	defer t.Logf("Finished measuring machine hash rate")
 
 	genesisBlock := dagconfig.DevnetParams.GenesisBlock
-	state := pow.NewMinerState(genesisBlock.Header.ToMutable())
+	state := pow.NewState(genesisBlock.Header.ToMutable())
 
 	machineHashesPerSecondMeasurementDuration := 10 * time.Second
 	hashes := int64(0)
@@ -199,7 +199,7 @@ func runDAATest(t *testing.T, testName string, runDuration time.Duration,
 	loopForDuration(runDuration, func(isFinished *bool) {
 		templateBlock := fetchBlockForMining(t, rpcClient)
 		headerForMining := templateBlock.Header.ToMutable()
-		minerState := pow.NewMinerState(headerForMining)
+		minerState := pow.NewState(headerForMining)
 
 		// Try hashes until we find a valid block
 		miningStartTime := time.Now()


### PR DESCRIPTION
This allows a miner to cache the matrix generation to improve the performance of the miner.
I implemented a `MinerCache` that caches: the matrix, the target, the PrePowHash.