### PR TITLE
Receive and skip pending relay invs while (slow) processing IBD headers

### DIFF
--- a/infrastructure/network/netadapter/router/route.go
+++ b/infrastructure/network/netadapter/router/route.go
@@ -89,6 +89,20 @@ func (r *Route) DequeueWithTimeout(timeout time.Duration) (appmessage.Message, e
 	}
 }
 
+// DequeueWithTimeoutNoTimeoutError attempts to dequeue a message from the Route
+// and returns nil if the given timeout expires first.
+func (r *Route) DequeueWithTimeoutNoTimeoutError(timeout time.Duration) (appmessage.Message, error) {
+	select {
+	case <-time.After(timeout):
+		return nil, nil
+	case message, isOpen := <-r.channel:
+		if !isOpen {
+			return nil, errors.WithStack(ErrRouteClosed)
+		}
+		return message, nil
+	}
+}
+
 // Close closes this route
 func (r *Route) Close() {
 	r.closeLock.Lock()


### PR DESCRIPTION
Currently if a node has performance issues during IBD and takes more than 100 seconds to process a bulk of headers, the connection to the IBD peer is aborted due to route capacity limit reached (since invs are not dequeued). This in turn causes the IBD to abort and delete the DB prefix, starting the whole process all over, sometimes in an infinite loop.

This PR fixes this by processing and skipping invs relay messages if the processing thread is busy. 

P.S. Perhaps a more fundamental solution would be to separate the IBD flow from invs relay flow.  