### PR TITLE
Split ApplyPruningPointProof to multiple small database transactions

### DIFF
--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -748,18 +748,7 @@ func (s *consensus) ApplyPruningPointProof(pruningPointProof *externalapi.Prunin
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	stagingArea := model.NewStagingArea()
-	err := s.pruningProofManager.ApplyPruningPointProof(stagingArea, pruningPointProof)
-	if err != nil {
-		return err
-	}
-
-	err = staging.CommitAllChanges(s.databaseContext, stagingArea)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.pruningProofManager.ApplyPruningPointProof(pruningPointProof)
 }
 
 func (s *consensus) BlockDAAWindowHashes(blockHash *externalapi.DomainHash) ([]*externalapi.DomainHash, error) {

--- a/domain/consensus/model/interface_processes_pruningproofmanager.go
+++ b/domain/consensus/model/interface_processes_pruningproofmanager.go
@@ -6,5 +6,5 @@ import "github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 type PruningProofManager interface {
 	BuildPruningPointProof(stagingArea *StagingArea) (*externalapi.PruningPointProof, error)
 	ValidatePruningPointProof(pruningPointProof *externalapi.PruningPointProof) error
-	ApplyPruningPointProof(stagingArea *StagingArea, pruningPointProof *externalapi.PruningPointProof) error
+	ApplyPruningPointProof(pruningPointProof *externalapi.PruningPointProof) error
 }

--- a/domain/consensus/processes/pruningproofmanager/pruningproofmanager.go
+++ b/domain/consensus/processes/pruningproofmanager/pruningproofmanager.go
@@ -608,6 +608,10 @@ func (ppm *pruningProofManager) dagProcesses(
 	return reachabilityManagers, dagTopologyManagers, ghostdagManagers
 }
 
+// ApplyPruningPointProof applies the given pruning proof to the current consensus. Specifically,
+// it's meant to be used against the StagingConsensus during headers-proof IBD. Note that for
+// performance reasons this operation is NOT atomic. If the process fails for whatever reason
+// (e.g. the process was killed) then the database for this consensus MUST be discarded.
 func (ppm *pruningProofManager) ApplyPruningPointProof(pruningPointProof *externalapi.PruningPointProof) error {
 	onEnd := logger.LogAndMeasureExecutionTime(log, "ApplyPruningPointProof")
 	defer onEnd()

--- a/stability-tests/simple-sync/mineloop.go
+++ b/stability-tests/simple-sync/mineloop.go
@@ -37,7 +37,7 @@ func mineLoop(syncerRPCClient, syncedRPCClient *rpc.Client) error {
 		}
 
 		start := time.Now()
-		const timeToPropagate = 10 * time.Second
+		const timeToPropagate = 30 * time.Second
 		select {
 		case <-syncedRPCClient.OnBlockAdded:
 		case <-time.After(timeToPropagate):

--- a/testing/integration/ibd_test.go
+++ b/testing/integration/ibd_test.go
@@ -89,7 +89,7 @@ func TestIBDWithPruning(t *testing.T) {
 
 		start := time.Now()
 		for range ticker.C {
-			if time.Since(start) > 2*defaultTimeout {
+			if time.Since(start) > 30*time.Second {
 				t.Fatalf("Timeout waiting for IBD to finish.")
 			}
 


### PR DESCRIPTION
This fixes https://github.com/kaspanet/kaspad/issues/1920

ApplyPruningPointProof is always called on the Staging Consensus during IBD, so there's no risk of data inconsistency.
This PR splits the writes from this function to the database to multiple small transactions, so that the garbage collector has a chance to clean up while data is being written
Note that it's still a big, quick write, so RAM consumption isn't reduced to zero. On my VM I've watched it consume up to 1gb additional memory throughout the process