### PR TITLE
Display progress of IBD process in Kaspad logs

### DIFF
--- a/app/protocol/flows/v3/blockrelay/ibd_progress_reporter.go
+++ b/app/protocol/flows/v3/blockrelay/ibd_progress_reporter.go
@@ -26,7 +26,7 @@ func (ipr *ibdProgressReporter) reportProgress(processedDelta int, highestProces
 	relativeDAAScore := highestProcessedDAAScore - ipr.lowDAAScore
 	progressPercent := int((float64(relativeDAAScore) / float64(ipr.totalDAAScoreDifference)) * 100)
 	if progressPercent > ipr.lastReportedProgressPercent {
-		log.Infof("IBD: Processed %d (%d%%) %s", ipr.processed, progressPercent, ipr.objectName)
+		log.Infof("IBD: Processed %d %s (%d%%)", ipr.processed, ipr.objectName, progressPercent)
 		ipr.lastReportedProgressPercent = progressPercent
 	}
 }

--- a/app/protocol/flows/v3/blockrelay/ibd_progress_reporter.go
+++ b/app/protocol/flows/v3/blockrelay/ibd_progress_reporter.go
@@ -1,0 +1,32 @@
+package blockrelay
+
+type ibdProgressReporter struct {
+	lowDAAScore                 uint64
+	highDAAScore                uint64
+	objectName                  string
+	totalDAAScoreDifference     uint64
+	lastReportedProgressPercent int
+	processed                   int
+}
+
+func newIBDProgressReporter(lowDAAScore uint64, highDAAScore uint64, objectName string) *ibdProgressReporter {
+	return &ibdProgressReporter{
+		lowDAAScore:                 lowDAAScore,
+		highDAAScore:                highDAAScore,
+		objectName:                  objectName,
+		totalDAAScoreDifference:     highDAAScore - lowDAAScore,
+		lastReportedProgressPercent: 0,
+		processed:                   0,
+	}
+}
+
+func (ipr *ibdProgressReporter) reportProgress(processedDelta int, highestProcessedDAAScore uint64) {
+	ipr.processed += processedDelta
+
+	relativeDAAScore := highestProcessedDAAScore - ipr.lowDAAScore
+	progressPercent := int((float64(relativeDAAScore) / float64(ipr.totalDAAScoreDifference)) * 100)
+	if progressPercent > ipr.lastReportedProgressPercent {
+		log.Infof("IBD: Processed %d (%d%%) %s", ipr.processed, progressPercent, ipr.objectName)
+		ipr.lastReportedProgressPercent = progressPercent
+	}
+}

--- a/app/protocol/flows/v3/blockrelay/ibd_with_headers_proof.go
+++ b/app/protocol/flows/v3/blockrelay/ibd_with_headers_proof.go
@@ -11,13 +11,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (flow *handleIBDFlow) ibdWithHeadersProof(highHash *externalapi.DomainHash) error {
+func (flow *handleIBDFlow) ibdWithHeadersProof(highHash *externalapi.DomainHash, highBlockDAAScore uint64) error {
 	err := flow.Domain().InitStagingConsensus()
 	if err != nil {
 		return err
 	}
 
-	err = flow.downloadHeadersAndPruningUTXOSet(highHash)
+	err = flow.downloadHeadersAndPruningUTXOSet(highHash, highBlockDAAScore)
 	if err != nil {
 		if !flow.IsRecoverableError(err) {
 			return err
@@ -113,7 +113,7 @@ func (flow *handleIBDFlow) syncAndValidatePruningPointProof() (*externalapi.Doma
 	return consensushashing.HeaderHash(pruningPointProof.Headers[0][len(pruningPointProof.Headers[0])-1]), nil
 }
 
-func (flow *handleIBDFlow) downloadHeadersAndPruningUTXOSet(highHash *externalapi.DomainHash) error {
+func (flow *handleIBDFlow) downloadHeadersAndPruningUTXOSet(highHash *externalapi.DomainHash, highBlockDAAScore uint64) error {
 	proofPruningPoint, err := flow.syncAndValidatePruningPointProof()
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func (flow *handleIBDFlow) downloadHeadersAndPruningUTXOSet(highHash *externalap
 		return protocolerrors.Errorf(true, "the genesis pruning point violates finality")
 	}
 
-	err = flow.syncPruningPointFutureHeaders(flow.Domain().StagingConsensus(), proofPruningPoint, highHash)
+	err = flow.syncPruningPointFutureHeaders(flow.Domain().StagingConsensus(), proofPruningPoint, highHash, highBlockDAAScore)
 	if err != nil {
 		return err
 	}

--- a/app/protocol/flows/v4/blockrelay/ibd_progress_reporter.go
+++ b/app/protocol/flows/v4/blockrelay/ibd_progress_reporter.go
@@ -26,7 +26,7 @@ func (ipr *ibdProgressReporter) reportProgress(processedDelta int, highestProces
 	relativeDAAScore := highestProcessedDAAScore - ipr.lowDAAScore
 	progressPercent := int((float64(relativeDAAScore) / float64(ipr.totalDAAScoreDifference)) * 100)
 	if progressPercent > ipr.lastReportedProgressPercent {
-		log.Infof("IBD: Processed %d (%d%%) %s", ipr.processed, progressPercent, ipr.objectName)
+		log.Infof("IBD: Processed %d %s (%d%%)", ipr.processed, ipr.objectName, progressPercent)
 		ipr.lastReportedProgressPercent = progressPercent
 	}
 }

--- a/app/protocol/flows/v4/blockrelay/ibd_progress_reporter.go
+++ b/app/protocol/flows/v4/blockrelay/ibd_progress_reporter.go
@@ -1,0 +1,32 @@
+package blockrelay
+
+type ibdProgressReporter struct {
+	lowDAAScore                 uint64
+	highDAAScore                uint64
+	objectName                  string
+	totalDAAScoreDifference     uint64
+	lastReportedProgressPercent int
+	processed                   int
+}
+
+func newIBDProgressReporter(lowDAAScore uint64, highDAAScore uint64, objectName string) *ibdProgressReporter {
+	return &ibdProgressReporter{
+		lowDAAScore:                 lowDAAScore,
+		highDAAScore:                highDAAScore,
+		objectName:                  objectName,
+		totalDAAScoreDifference:     highDAAScore - lowDAAScore,
+		lastReportedProgressPercent: 0,
+		processed:                   0,
+	}
+}
+
+func (ipr *ibdProgressReporter) reportProgress(processedDelta int, highestProcessedDAAScore uint64) {
+	ipr.processed += processedDelta
+
+	relativeDAAScore := highestProcessedDAAScore - ipr.lowDAAScore
+	progressPercent := int((float64(relativeDAAScore) / float64(ipr.totalDAAScoreDifference)) * 100)
+	if progressPercent > ipr.lastReportedProgressPercent {
+		log.Infof("IBD: Processed %d (%d%%) %s", ipr.processed, progressPercent, ipr.objectName)
+		ipr.lastReportedProgressPercent = progressPercent
+	}
+}

--- a/app/protocol/flows/v4/blockrelay/ibd_with_headers_proof.go
+++ b/app/protocol/flows/v4/blockrelay/ibd_with_headers_proof.go
@@ -11,13 +11,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (flow *handleIBDFlow) ibdWithHeadersProof(highHash *externalapi.DomainHash) error {
+func (flow *handleIBDFlow) ibdWithHeadersProof(highHash *externalapi.DomainHash, highBlockDAAScore uint64) error {
 	err := flow.Domain().InitStagingConsensus()
 	if err != nil {
 		return err
 	}
 
-	err = flow.downloadHeadersAndPruningUTXOSet(highHash)
+	err = flow.downloadHeadersAndPruningUTXOSet(highHash, highBlockDAAScore)
 	if err != nil {
 		if !flow.IsRecoverableError(err) {
 			return err
@@ -113,7 +113,7 @@ func (flow *handleIBDFlow) syncAndValidatePruningPointProof() (*externalapi.Doma
 	return consensushashing.HeaderHash(pruningPointProof.Headers[0][len(pruningPointProof.Headers[0])-1]), nil
 }
 
-func (flow *handleIBDFlow) downloadHeadersAndPruningUTXOSet(highHash *externalapi.DomainHash) error {
+func (flow *handleIBDFlow) downloadHeadersAndPruningUTXOSet(highHash *externalapi.DomainHash, highBlockDAAScore uint64) error {
 	proofPruningPoint, err := flow.syncAndValidatePruningPointProof()
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func (flow *handleIBDFlow) downloadHeadersAndPruningUTXOSet(highHash *externalap
 		return protocolerrors.Errorf(true, "the genesis pruning point violates finality")
 	}
 
-	err = flow.syncPruningPointFutureHeaders(flow.Domain().StagingConsensus(), proofPruningPoint, highHash)
+	err = flow.syncPruningPointFutureHeaders(flow.Domain().StagingConsensus(), proofPruningPoint, highHash, highBlockDAAScore)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This implements https://github.com/kaspanet/kaspad/issues/1912

Reports for both protocol version 3 and 4 are added, for both header and block downloads

The reports look like this:
`2022-01-30 16:37:14.450 [INF] PROT: IBD: Processed 63600 blocks (28%)`