### PR TITLE
Fix bookkeeping of chained transactions in mempool

### DIFF
--- a/domain/miningmanager/mempool/fill_inputs_and_get_missing_parents.go
+++ b/domain/miningmanager/mempool/fill_inputs_and_get_missing_parents.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (mp *mempool) fillInputsAndGetMissingParents(transaction *externalapi.DomainTransaction) (
-	parents model.OutpointToTransactionMap, missingOutpoints []*externalapi.DomainOutpoint, err error) {
+	parents model.IDToTransactionMap, missingOutpoints []*externalapi.DomainOutpoint, err error) {
 
 	parentsInPool := mp.transactionsPool.getParentTransactionsInPool(transaction)
 
@@ -34,9 +34,9 @@ func (mp *mempool) fillInputsAndGetMissingParents(transaction *externalapi.Domai
 	return parentsInPool, nil, nil
 }
 
-func fillInputs(transaction *externalapi.DomainTransaction, parentsInPool model.OutpointToTransactionMap) {
+func fillInputs(transaction *externalapi.DomainTransaction, parentsInPool model.IDToTransactionMap) {
 	for _, input := range transaction.Inputs {
-		parent, ok := parentsInPool[input.PreviousOutpoint]
+		parent, ok := parentsInPool[input.PreviousOutpoint.TransactionID]
 		if !ok {
 			continue
 		}

--- a/domain/miningmanager/mempool/model/map_types.go
+++ b/domain/miningmanager/mempool/model/map_types.go
@@ -7,6 +7,9 @@ import (
 // IDToTransactionMap maps transactionID to a MempoolTransaction
 type IDToTransactionMap map[externalapi.DomainTransactionID]*MempoolTransaction
 
+// IDToTransactionsSliceMap maps transactionID to a slice MempoolTransaction
+type IDToTransactionsSliceMap map[externalapi.DomainTransactionID][]*MempoolTransaction
+
 // OutpointToUTXOEntryMap maps an outpoint to a UTXOEntry
 type OutpointToUTXOEntryMap map[externalapi.DomainOutpoint]externalapi.UTXOEntry
 

--- a/domain/miningmanager/mempool/model/mempool_transaction.go
+++ b/domain/miningmanager/mempool/model/mempool_transaction.go
@@ -8,7 +8,7 @@ import (
 // MempoolTransaction represents a transaction inside the main TransactionPool
 type MempoolTransaction struct {
 	transaction              *externalapi.DomainTransaction
-	parentTransactionsInPool OutpointToTransactionMap
+	parentTransactionsInPool IDToTransactionMap
 	isHighPriority           bool
 	addedAtDAAScore          uint64
 }
@@ -16,7 +16,7 @@ type MempoolTransaction struct {
 // NewMempoolTransaction constructs a new MempoolTransaction
 func NewMempoolTransaction(
 	transaction *externalapi.DomainTransaction,
-	parentTransactionsInPool OutpointToTransactionMap,
+	parentTransactionsInPool IDToTransactionMap,
 	isHighPriority bool,
 	addedAtDAAScore uint64,
 ) *MempoolTransaction {
@@ -39,8 +39,12 @@ func (mt *MempoolTransaction) Transaction() *externalapi.DomainTransaction {
 }
 
 // ParentTransactionsInPool a list of parent transactions that exist in the mempool, indexed by outpoint
-func (mt *MempoolTransaction) ParentTransactionsInPool() OutpointToTransactionMap {
+func (mt *MempoolTransaction) ParentTransactionsInPool() IDToTransactionMap {
 	return mt.parentTransactionsInPool
+}
+
+func (mt *MempoolTransaction) RemoveParentTransactionInPool(transactionID *externalapi.DomainTransactionID) {
+	delete(mt.parentTransactionsInPool, *transactionID)
 }
 
 // IsHighPriority returns whether this MempoolTransaction is a high-priority one

--- a/domain/miningmanager/mempool/model/mempool_transaction.go
+++ b/domain/miningmanager/mempool/model/mempool_transaction.go
@@ -43,6 +43,7 @@ func (mt *MempoolTransaction) ParentTransactionsInPool() IDToTransactionMap {
 	return mt.parentTransactionsInPool
 }
 
+// RemoveParentTransactionInPool deletes a transaction from the parentTransactionsInPool set
 func (mt *MempoolTransaction) RemoveParentTransactionInPool(transactionID *externalapi.DomainTransactionID) {
 	delete(mt.parentTransactionsInPool, *transactionID)
 }

--- a/domain/miningmanager/mempool/remove_transaction.go
+++ b/domain/miningmanager/mempool/remove_transaction.go
@@ -27,9 +27,13 @@ func (mp *mempool) removeTransaction(transactionID *externalapi.DomainTransactio
 	}
 
 	transactionsToRemove := []*model.MempoolTransaction{mempoolTransaction}
+	redeemers := mp.transactionsPool.getRedeemers(mempoolTransaction)
 	if removeRedeemers {
-		redeemers := mp.transactionsPool.getRedeemers(mempoolTransaction)
 		transactionsToRemove = append(transactionsToRemove, redeemers...)
+	} else {
+		for _, redeemer := range redeemers {
+			redeemer.RemoveParentTransactionInPool(transactionID)
+		}
 	}
 
 	for _, transactionToRemove := range transactionsToRemove {


### PR DESCRIPTION
This PR fixes two bugs in mempool related to chained transactions:
1. Bookeeping of chained transactions was faulty, causing getRedeemers to infinite-loop when there's a chained transaction in the pool.
2. mempoolTransaction.parentTransactionsInPool was never cleared when the parents are removed from the pool, causing child transactions to stay in mempool for ever.