### PR TITLE
Set MaxBlockLevels for non-mainnet networks to 250

### DIFF
--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kaspanet/kaspad/domain/consensus/processes/blockparentbuilder"
 	parentssanager "github.com/kaspanet/kaspad/domain/consensus/processes/parentsmanager"
 	"github.com/kaspanet/kaspad/domain/consensus/processes/pruningproofmanager"
-	"github.com/kaspanet/kaspad/domain/consensus/utils/constants"
 	"io/ioutil"
 	"os"
 	"sync"
@@ -158,7 +157,7 @@ func (f *factory) NewConsensus(config *Config, db infrastructuredatabase.Databas
 	dagTraversalManager := dagTraversalManagers[0]
 
 	// Processes
-	parentsManager := parentssanager.New(config.GenesisHash)
+	parentsManager := parentssanager.New(config.GenesisHash, config.MaxBlockLevel)
 	blockParentBuilder := blockparentbuilder.New(
 		dbManager,
 		blockHeaderStore,
@@ -168,6 +167,7 @@ func (f *factory) NewConsensus(config *Config, db infrastructuredatabase.Databas
 		pruningStore,
 
 		config.GenesisHash,
+		config.MaxBlockLevel,
 	)
 	pastMedianTimeManager := f.pastMedianTimeConsructor(
 		config.TimestampDeviationTolerance,
@@ -304,6 +304,7 @@ func (f *factory) NewConsensus(config *Config, db infrastructuredatabase.Databas
 		config.TimestampDeviationTolerance,
 		config.TargetTimePerBlock,
 		config.IgnoreHeaderMass,
+		config.MaxBlockLevel,
 
 		dbManager,
 		difficultyManager,
@@ -370,6 +371,7 @@ func (f *factory) NewConsensus(config *Config, db infrastructuredatabase.Databas
 	blockProcessor := blockprocessor.New(
 		genesisHash,
 		config.TargetTimePerBlock,
+		config.MaxBlockLevel,
 		dbManager,
 		consensusStateManager,
 		pruningManager,
@@ -417,6 +419,7 @@ func (f *factory) NewConsensus(config *Config, db infrastructuredatabase.Databas
 		genesisHash,
 		config.K,
 		config.PruningProofM,
+		config.MaxBlockLevel,
 	)
 
 	c := &consensus{
@@ -568,16 +571,16 @@ func dagStores(config *Config,
 	pruningWindowSizePlusFinalityDepthForCache, pruningWindowSizeForCaches int,
 	preallocateCaches bool) ([]model.BlockRelationStore, []model.ReachabilityDataStore, []model.GHOSTDAGDataStore) {
 
-	blockRelationStores := make([]model.BlockRelationStore, constants.MaxBlockLevel+1)
-	reachabilityDataStores := make([]model.ReachabilityDataStore, constants.MaxBlockLevel+1)
-	ghostdagDataStores := make([]model.GHOSTDAGDataStore, constants.MaxBlockLevel+1)
+	blockRelationStores := make([]model.BlockRelationStore, config.MaxBlockLevel+1)
+	reachabilityDataStores := make([]model.ReachabilityDataStore, config.MaxBlockLevel+1)
+	ghostdagDataStores := make([]model.GHOSTDAGDataStore, config.MaxBlockLevel+1)
 
 	ghostdagDataCacheSize := pruningWindowSizeForCaches * 2
 	if ghostdagDataCacheSize < config.DifficultyAdjustmentWindowSize {
 		ghostdagDataCacheSize = config.DifficultyAdjustmentWindowSize
 	}
 
-	for i := 0; i <= constants.MaxBlockLevel; i++ {
+	for i := 0; i <= config.MaxBlockLevel; i++ {
 		prefixBucket := prefixBucket.Bucket([]byte{byte(i)})
 		if i == 0 {
 			blockRelationStores[i] = blockrelationstore.New(prefixBucket, pruningWindowSizePlusFinalityDepthForCache, preallocateCaches)
@@ -606,12 +609,12 @@ func (f *factory) dagProcesses(config *Config,
 	[]model.DAGTraversalManager,
 ) {
 
-	reachabilityManagers := make([]model.ReachabilityManager, constants.MaxBlockLevel+1)
-	dagTopologyManagers := make([]model.DAGTopologyManager, constants.MaxBlockLevel+1)
-	ghostdagManagers := make([]model.GHOSTDAGManager, constants.MaxBlockLevel+1)
-	dagTraversalManagers := make([]model.DAGTraversalManager, constants.MaxBlockLevel+1)
+	reachabilityManagers := make([]model.ReachabilityManager, config.MaxBlockLevel+1)
+	dagTopologyManagers := make([]model.DAGTopologyManager, config.MaxBlockLevel+1)
+	ghostdagManagers := make([]model.GHOSTDAGManager, config.MaxBlockLevel+1)
+	dagTraversalManagers := make([]model.DAGTraversalManager, config.MaxBlockLevel+1)
 
-	for i := 0; i <= constants.MaxBlockLevel; i++ {
+	for i := 0; i <= config.MaxBlockLevel; i++ {
 		reachabilityManagers[i] = reachabilitymanager.New(
 			dbManager,
 			ghostdagDataStores[i],

--- a/domain/consensus/model/externalapi/block.go
+++ b/domain/consensus/model/externalapi/block.go
@@ -69,7 +69,7 @@ type BaseBlockHeader interface {
 	BlueScore() uint64
 	BlueWork() *big.Int
 	PruningPoint() *DomainHash
-	BlockLevel() int
+	BlockLevel(maxBlockLevel int) int
 	Equal(other BaseBlockHeader) bool
 }
 

--- a/domain/consensus/processes/blockparentbuilder/blockparentbuilder.go
+++ b/domain/consensus/processes/blockparentbuilder/blockparentbuilder.go
@@ -16,7 +16,8 @@ type blockParentBuilder struct {
 	reachabilityDataStore model.ReachabilityDataStore
 	pruningStore          model.PruningStore
 
-	genesisHash *externalapi.DomainHash
+	genesisHash   *externalapi.DomainHash
+	maxBlockLevel int
 }
 
 // New creates a new instance of a BlockParentBuilder
@@ -30,6 +31,7 @@ func New(
 	pruningStore model.PruningStore,
 
 	genesisHash *externalapi.DomainHash,
+	maxBlockLevel int,
 ) model.BlockParentBuilder {
 	return &blockParentBuilder{
 		databaseContext:    databaseContext,
@@ -40,6 +42,7 @@ func New(
 		reachabilityDataStore: reachabilityDataStore,
 		pruningStore:          pruningStore,
 		genesisHash:           genesisHash,
+		maxBlockLevel:         maxBlockLevel,
 	}
 }
 
@@ -102,7 +105,7 @@ func (bpb *blockParentBuilder) BuildParents(stagingArea *model.StagingArea,
 	// all the block levels they occupy
 	for _, directParentHeader := range directParentHeaders {
 		directParentHash := consensushashing.HeaderHash(directParentHeader)
-		blockLevel := directParentHeader.BlockLevel()
+		blockLevel := directParentHeader.BlockLevel(bpb.maxBlockLevel)
 		for i := 0; i <= blockLevel; i++ {
 			if _, exists := candidatesByLevelToReferenceBlocksMap[i]; !exists {
 				candidatesByLevelToReferenceBlocksMap[i] = make(map[externalapi.DomainHash][]*externalapi.DomainHash)

--- a/domain/consensus/processes/blockprocessor/blockprocessor.go
+++ b/domain/consensus/processes/blockprocessor/blockprocessor.go
@@ -14,6 +14,7 @@ import (
 type blockProcessor struct {
 	genesisHash        *externalapi.DomainHash
 	targetTimePerBlock time.Duration
+	maxBlockLevel      int
 	databaseContext    model.DBManager
 	blockLogger        *blocklogger.BlockLogger
 
@@ -52,6 +53,7 @@ type blockProcessor struct {
 func New(
 	genesisHash *externalapi.DomainHash,
 	targetTimePerBlock time.Duration,
+	maxBlockLevel int,
 	databaseContext model.DBManager,
 
 	consensusStateManager model.ConsensusStateManager,
@@ -86,6 +88,7 @@ func New(
 	return &blockProcessor{
 		genesisHash:           genesisHash,
 		targetTimePerBlock:    targetTimePerBlock,
+		maxBlockLevel:         maxBlockLevel,
 		databaseContext:       databaseContext,
 		blockLogger:           blocklogger.NewBlockLogger(),
 		pruningManager:        pruningManager,

--- a/domain/consensus/processes/blockprocessor/validate_and_insert_block.go
+++ b/domain/consensus/processes/blockprocessor/validate_and_insert_block.go
@@ -259,7 +259,7 @@ func (bp *blockProcessor) updateReachabilityReindexRoot(stagingArea *model.Stagi
 		return err
 	}
 
-	headersSelectedTipHeaderBlockLevel := headersSelectedTipHeader.BlockLevel()
+	headersSelectedTipHeaderBlockLevel := headersSelectedTipHeader.BlockLevel(bp.maxBlockLevel)
 	for blockLevel := 0; blockLevel <= headersSelectedTipHeaderBlockLevel; blockLevel++ {
 		err := bp.reachabilityManagers[blockLevel].UpdateReindexRoot(stagingArea, headersSelectedTip)
 		if err != nil {

--- a/domain/consensus/processes/blockvalidator/block_header_in_context.go
+++ b/domain/consensus/processes/blockvalidator/block_header_in_context.go
@@ -62,7 +62,7 @@ func (v *blockValidator) ValidateHeaderInContext(stagingArea *model.StagingArea,
 		return err
 	}
 	if !hasReachabilityData {
-		blockLevel := header.BlockLevel()
+		blockLevel := header.BlockLevel(v.maxBlockLevel)
 		for i := 0; i <= blockLevel; i++ {
 			err = v.reachabilityManagers[i].AddBlock(stagingArea, blockHash)
 			if err != nil {

--- a/domain/consensus/processes/blockvalidator/blockvalidator.go
+++ b/domain/consensus/processes/blockvalidator/blockvalidator.go
@@ -23,6 +23,7 @@ type blockValidator struct {
 	timestampDeviationTolerance int
 	targetTimePerBlock          time.Duration
 	ignoreHeaderMass            bool
+	maxBlockLevel               int
 
 	databaseContext       model.DBReader
 	difficultyManager     model.DifficultyManager
@@ -60,6 +61,7 @@ func New(powMax *big.Int,
 	timestampDeviationTolerance int,
 	targetTimePerBlock time.Duration,
 	ignoreHeaderMass bool,
+	maxBlockLevel int,
 
 	databaseContext model.DBReader,
 
@@ -97,6 +99,7 @@ func New(powMax *big.Int,
 		mergeSetSizeLimit:          mergeSetSizeLimit,
 		maxBlockParents:            maxBlockParents,
 		ignoreHeaderMass:           ignoreHeaderMass,
+		maxBlockLevel:              maxBlockLevel,
 
 		timestampDeviationTolerance: timestampDeviationTolerance,
 		targetTimePerBlock:          targetTimePerBlock,

--- a/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty.go
+++ b/domain/consensus/processes/blockvalidator/pruning_violation_proof_of_work_and_difficulty.go
@@ -69,7 +69,7 @@ func (v *blockValidator) setParents(stagingArea *model.StagingArea,
 	header externalapi.BlockHeader,
 	isBlockWithTrustedData bool) error {
 
-	for level := 0; level <= header.BlockLevel(); level++ {
+	for level := 0; level <= header.BlockLevel(v.maxBlockLevel); level++ {
 		var parents []*externalapi.DomainHash
 		for _, parent := range v.parentsManager.ParentsAtLevel(header, level) {
 			_, err := v.ghostdagDataStores[level].Get(v.databaseContext, stagingArea, parent, false)
@@ -118,7 +118,7 @@ func (v *blockValidator) validateDifficulty(stagingArea *model.StagingArea,
 		return err
 	}
 
-	blockLevel := header.BlockLevel()
+	blockLevel := header.BlockLevel(v.maxBlockLevel)
 	for i := 1; i <= blockLevel; i++ {
 		err = v.ghostdagManagers[i].GHOSTDAG(stagingArea, blockHash)
 		if err != nil {

--- a/domain/consensus/processes/dagtraversalmanager/window_test.go
+++ b/domain/consensus/processes/dagtraversalmanager/window_test.go
@@ -205,37 +205,37 @@ func TestBlockWindow(t *testing.T) {
 			{
 				parents:        []string{"H", "F"},
 				id:             "I",
-				expectedWindow: []string{"F", "H", "D", "C", "G", "B"},
+				expectedWindow: []string{"F", "D", "H", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"I"},
 				id:             "J",
-				expectedWindow: []string{"I", "F", "H", "D", "C", "G", "B"},
+				expectedWindow: []string{"I", "F", "D", "H", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"J"},
 				id:             "K",
-				expectedWindow: []string{"J", "I", "F", "H", "D", "C", "G", "B"},
+				expectedWindow: []string{"J", "I", "F", "D", "H", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"K"},
 				id:             "L",
-				expectedWindow: []string{"K", "J", "I", "F", "H", "D", "C", "G", "B"},
+				expectedWindow: []string{"K", "J", "I", "F", "D", "H", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"L"},
 				id:             "M",
-				expectedWindow: []string{"L", "K", "J", "I", "F", "H", "D", "C", "G", "B"},
+				expectedWindow: []string{"L", "K", "J", "I", "F", "D", "H", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"M"},
 				id:             "N",
-				expectedWindow: []string{"M", "L", "K", "J", "I", "F", "H", "D", "C", "G"},
+				expectedWindow: []string{"M", "L", "K", "J", "I", "F", "D", "H", "C", "G"},
 			},
 			{
 				parents:        []string{"N"},
 				id:             "O",
-				expectedWindow: []string{"N", "M", "L", "K", "J", "I", "F", "H", "D", "C"},
+				expectedWindow: []string{"N", "M", "L", "K", "J", "I", "F", "D", "H", "C"},
 			},
 		},
 		dagconfig.SimnetParams.Name: {

--- a/domain/consensus/processes/dagtraversalmanager/window_test.go
+++ b/domain/consensus/processes/dagtraversalmanager/window_test.go
@@ -205,37 +205,37 @@ func TestBlockWindow(t *testing.T) {
 			{
 				parents:        []string{"H", "F"},
 				id:             "I",
-				expectedWindow: []string{"F", "D", "H", "C", "G", "B"},
+				expectedWindow: []string{"F", "H", "D", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"I"},
 				id:             "J",
-				expectedWindow: []string{"I", "F", "D", "H", "C", "G", "B"},
+				expectedWindow: []string{"I", "F", "H", "D", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"J"},
 				id:             "K",
-				expectedWindow: []string{"J", "I", "F", "D", "H", "C", "G", "B"},
+				expectedWindow: []string{"J", "I", "F", "H", "D", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"K"},
 				id:             "L",
-				expectedWindow: []string{"K", "J", "I", "F", "D", "H", "C", "G", "B"},
+				expectedWindow: []string{"K", "J", "I", "F", "H", "D", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"L"},
 				id:             "M",
-				expectedWindow: []string{"L", "K", "J", "I", "F", "D", "H", "C", "G", "B"},
+				expectedWindow: []string{"L", "K", "J", "I", "F", "H", "D", "C", "G", "B"},
 			},
 			{
 				parents:        []string{"M"},
 				id:             "N",
-				expectedWindow: []string{"M", "L", "K", "J", "I", "F", "D", "H", "C", "G"},
+				expectedWindow: []string{"M", "L", "K", "J", "I", "F", "H", "D", "C", "G"},
 			},
 			{
 				parents:        []string{"N"},
 				id:             "O",
-				expectedWindow: []string{"N", "M", "L", "K", "J", "I", "F", "D", "H", "C"},
+				expectedWindow: []string{"N", "M", "L", "K", "J", "I", "F", "H", "D", "C"},
 			},
 		},
 		dagconfig.SimnetParams.Name: {

--- a/domain/consensus/processes/parentsmanager/parentsmanager.go
+++ b/domain/consensus/processes/parentsmanager/parentsmanager.go
@@ -3,17 +3,18 @@ package parentssanager
 import (
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
-	"github.com/kaspanet/kaspad/domain/consensus/utils/constants"
 )
 
 type parentsManager struct {
-	genesisHash *externalapi.DomainHash
+	genesisHash   *externalapi.DomainHash
+	maxBlockLevel int
 }
 
 // New instantiates a new ParentsManager
-func New(genesisHash *externalapi.DomainHash) model.ParentsManager {
+func New(genesisHash *externalapi.DomainHash, maxBlockLevel int) model.ParentsManager {
 	return &parentsManager{
-		genesisHash: genesisHash,
+		genesisHash:   genesisHash,
+		maxBlockLevel: maxBlockLevel,
 	}
 }
 
@@ -31,7 +32,7 @@ func (pm *parentsManager) ParentsAtLevel(blockHeader externalapi.BlockHeader, le
 }
 
 func (pm *parentsManager) Parents(blockHeader externalapi.BlockHeader) []externalapi.BlockLevelParents {
-	numParents := constants.MaxBlockLevel + 1
+	numParents := pm.maxBlockLevel + 1
 	parents := make([]externalapi.BlockLevelParents, numParents)
 	for i := 0; i < numParents; i++ {
 		parents[i] = pm.ParentsAtLevel(blockHeader, i)

--- a/domain/consensus/processes/pruningmanager/pruning_test.go
+++ b/domain/consensus/processes/pruningmanager/pruning_test.go
@@ -38,8 +38,8 @@ func TestPruning(t *testing.T) {
 		"dag-for-test-pruning.json": {
 			dagconfig.MainnetParams.Name: "503",
 			dagconfig.TestnetParams.Name: "502",
-			dagconfig.DevnetParams.Name:  "503",
-			dagconfig.SimnetParams.Name:  "502",
+			dagconfig.DevnetParams.Name:  "502",
+			dagconfig.SimnetParams.Name:  "503",
 		},
 	}
 

--- a/domain/consensus/utils/blockheader/blockheader.go
+++ b/domain/consensus/utils/blockheader/blockheader.go
@@ -179,9 +179,9 @@ func (bh *blockHeader) ToMutable() externalapi.MutableBlockHeader {
 	return bh.clone()
 }
 
-func (bh *blockHeader) BlockLevel() int {
+func (bh *blockHeader) BlockLevel(maxBlockLevel int) int {
 	if !bh.isBlockLevelCached {
-		bh.blockLevel = pow.BlockLevel(bh)
+		bh.blockLevel = pow.BlockLevel(bh, maxBlockLevel)
 		bh.isBlockLevelCached = true
 	}
 

--- a/domain/consensus/utils/constants/constants.go
+++ b/domain/consensus/utils/constants/constants.go
@@ -35,9 +35,4 @@ const (
 	// LockTimeThreshold is the number below which a lock time is
 	// interpreted to be a DAA score.
 	LockTimeThreshold = 5e11 // Tue Nov 5 00:53:20 1985 UTC
-
-	// MaxBlockLevel is the maximum possible block level.
-	// This is technically 255, but we clamped it at 256 - block level of mainnet genesis
-	// This means that any block that has a level lower or equal to genesis will be level 0.
-	MaxBlockLevel = 225
 )

--- a/domain/consensus/utils/pow/pow.go
+++ b/domain/consensus/utils/pow/pow.go
@@ -3,7 +3,6 @@ package pow
 import (
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/consensushashing"
-	"github.com/kaspanet/kaspad/domain/consensus/utils/constants"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/hashes"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/serialization"
 	"github.com/kaspanet/kaspad/util/difficulty"
@@ -96,15 +95,15 @@ func toBig(hash *externalapi.DomainHash) *big.Int {
 }
 
 // BlockLevel returns the block level of the given header.
-func BlockLevel(header externalapi.BlockHeader) int {
+func BlockLevel(header externalapi.BlockHeader, maxBlockLevel int) int {
 	// Genesis is defined to be the root of all blocks at all levels, so we define it to be the maximal
 	// block level.
 	if len(header.DirectParents()) == 0 {
-		return constants.MaxBlockLevel
+		return maxBlockLevel
 	}
 
 	proofOfWorkValue := NewState(header.ToMutable()).CalculateProofOfWorkValue()
-	level := constants.MaxBlockLevel - proofOfWorkValue.BitLen()
+	level := maxBlockLevel - proofOfWorkValue.BitLen()
 	// If the block has a level lower than genesis make it zero.
 	if level < 0 {
 		level = 0

--- a/domain/dagconfig/params.go
+++ b/domain/dagconfig/params.go
@@ -185,6 +185,9 @@ type Params struct {
 	DisallowDirectBlocksOnTopOfGenesis bool
 
 	IgnoreHeaderMass bool
+
+	// MaxBlockLevel is the maximum possible block level.
+	MaxBlockLevel int
 }
 
 // NormalizeRPCServerAddress returns addr with the current network default
@@ -279,6 +282,10 @@ var MainnetParams = Params{
 	PruningProofM:                           defaultPruningProofM,
 	DeflationaryPhaseDaaScore:               defaultDeflationaryPhaseDaaScore,
 	DisallowDirectBlocksOnTopOfGenesis:      true,
+
+	// This is technically 255, but we clamped it at 256 - block level of mainnet genesis
+	// This means that any block that has a level lower or equal to genesis will be level 0.
+	MaxBlockLevel: 225,
 }
 
 // TestnetParams defines the network parameters for the test Kaspa network.
@@ -339,6 +346,8 @@ var TestnetParams = Params{
 	PruningProofM:                           defaultPruningProofM,
 	DeflationaryPhaseDaaScore:               defaultDeflationaryPhaseDaaScore,
 	IgnoreHeaderMass:                        true,
+
+	MaxBlockLevel: 255,
 }
 
 // SimnetParams defines the network parameters for the simulation test Kaspa
@@ -402,6 +411,8 @@ var SimnetParams = Params{
 	CoinbasePayloadScriptPublicKeyMaxLength: defaultCoinbasePayloadScriptPublicKeyMaxLength,
 	PruningProofM:                           defaultPruningProofM,
 	DeflationaryPhaseDaaScore:               defaultDeflationaryPhaseDaaScore,
+
+	MaxBlockLevel: 255,
 }
 
 // DevnetParams defines the network parameters for the development Kaspa network.
@@ -462,6 +473,8 @@ var DevnetParams = Params{
 	PruningProofM:                           defaultPruningProofM,
 	DeflationaryPhaseDaaScore:               defaultDeflationaryPhaseDaaScore,
 	IgnoreHeaderMass:                        true,
+
+	MaxBlockLevel: 255,
 }
 
 // ErrDuplicateNet describes an error where the parameters for a Kaspa

--- a/domain/dagconfig/params.go
+++ b/domain/dagconfig/params.go
@@ -291,11 +291,11 @@ var MainnetParams = Params{
 // TestnetParams defines the network parameters for the test Kaspa network.
 var TestnetParams = Params{
 	K:           defaultGHOSTDAGK,
-	Name:        "kaspa-testnet-8",
+	Name:        "kaspa-testnet-9",
 	Net:         appmessage.Testnet,
 	RPCPort:     "16210",
 	DefaultPort: "16211",
-	DNSSeeds:    []string{"testnet-8-dnsseed.daglabs-dev.com"},
+	DNSSeeds:    []string{"testnet-9-dnsseed.daglabs-dev.com"},
 
 	// DAG parameters
 	GenesisBlock:                    &testnetGenesisBlock,

--- a/domain/dagconfig/params.go
+++ b/domain/dagconfig/params.go
@@ -347,7 +347,7 @@ var TestnetParams = Params{
 	DeflationaryPhaseDaaScore:               defaultDeflationaryPhaseDaaScore,
 	IgnoreHeaderMass:                        true,
 
-	MaxBlockLevel: 255,
+	MaxBlockLevel: 250,
 }
 
 // SimnetParams defines the network parameters for the simulation test Kaspa
@@ -412,7 +412,7 @@ var SimnetParams = Params{
 	PruningProofM:                           defaultPruningProofM,
 	DeflationaryPhaseDaaScore:               defaultDeflationaryPhaseDaaScore,
 
-	MaxBlockLevel: 255,
+	MaxBlockLevel: 250,
 }
 
 // DevnetParams defines the network parameters for the development Kaspa network.
@@ -474,7 +474,7 @@ var DevnetParams = Params{
 	DeflationaryPhaseDaaScore:               defaultDeflationaryPhaseDaaScore,
 	IgnoreHeaderMass:                        true,
 
-	MaxBlockLevel: 255,
+	MaxBlockLevel: 250,
 }
 
 // ErrDuplicateNet describes an error where the parameters for a Kaspa


### PR DESCRIPTION
Testnet difficulty is significantly lower than mainnet's. Mainnet's MaxBlockLevel caused testnet to keep significantly more block levels than necessary in RAM, causing OoM crashes and such.

This PR makes MaxBlockLevel depend on the network, and sets it to 250 for non-mainnet networks.