### PR TITLE
Ignore transaction invs on IBD

### DIFF
--- a/app/protocol/flows/v4/transactionrelay/handle_relayed_transactions.go
+++ b/app/protocol/flows/v4/transactionrelay/handle_relayed_transactions.go
@@ -22,6 +22,7 @@ type TransactionsRelayContext interface {
 	SharedRequestedTransactions() *flowcontext.SharedRequestedTransactions
 	OnTransactionAddedToMempool()
 	EnqueueTransactionIDsForPropagation(transactionIDs []*externalapi.DomainTransactionID) error
+	IsIBDRunning() bool
 }
 
 type handleRelayedTransactionsFlow struct {
@@ -47,6 +48,10 @@ func (flow *handleRelayedTransactionsFlow) start() error {
 		inv, err := flow.readInv()
 		if err != nil {
 			return err
+		}
+
+		if flow.IsIBDRunning() {
+			continue
 		}
 
 		requestedIDs, err := flow.requestInvTransactions(inv)


### PR DESCRIPTION
Adding new transactions to the pool during IBD can really slow it down