### PR TITLE
Make findTransactionIndex return wasFound explicitly + fix crash caused by invalid handling of not found transaction

### DIFF
--- a/domain/miningmanager/mempool/model/ordered_transactions_by_fee_rate.go
+++ b/domain/miningmanager/mempool/model/ordered_transactions_by_fee_rate.go
@@ -18,7 +18,7 @@ func (tobf *TransactionsOrderedByFeeRate) GetByIndex(index int) *MempoolTransact
 
 // Push inserts a transaction into the set, placing it in the correct place to preserve order
 func (tobf *TransactionsOrderedByFeeRate) Push(transaction *MempoolTransaction) error {
-	index, err := tobf.findTransactionIndex(transaction)
+	index, _, err := tobf.findTransactionIndex(transaction)
 	if err != nil {
 		return err
 	}
@@ -33,14 +33,13 @@ func (tobf *TransactionsOrderedByFeeRate) Push(transaction *MempoolTransaction) 
 // Returns an error if transaction does not exist in the set, or if the given transaction does not have mass
 // and fee filled in.
 func (tobf *TransactionsOrderedByFeeRate) Remove(transaction *MempoolTransaction) error {
-	index, err := tobf.findTransactionIndex(transaction)
+	index, wasFound, err := tobf.findTransactionIndex(transaction)
 	if err != nil {
 		return err
 	}
 
-	txID := transaction.TransactionID()
-	if !tobf.slice[index].TransactionID().Equal(txID) {
-		return errors.Errorf("Couldn't find %s in mp.orderedTransactionsByFeeRate", txID)
+	if !wasFound {
+		return errors.Errorf("Couldn't find %s in mp.orderedTransactionsByFeeRate", transaction.TransactionID())
 	}
 
 	return tobf.RemoveAtIndex(index)
@@ -56,15 +55,15 @@ func (tobf *TransactionsOrderedByFeeRate) RemoveAtIndex(index int) error {
 	return nil
 }
 
-func (tobf *TransactionsOrderedByFeeRate) findTransactionIndex(transaction *MempoolTransaction) (int, error) {
+func (tobf *TransactionsOrderedByFeeRate) findTransactionIndex(transaction *MempoolTransaction) (index int, wasFound bool, err error) {
 	if transaction.Transaction().Fee == 0 || transaction.Transaction().Mass == 0 {
-		return 0, errors.Errorf("findTxIndexInOrderedTransactionsByFeeRate expects a transaction with " +
+		return 0, false, errors.Errorf("findTxIndexInOrderedTransactionsByFeeRate expects a transaction with " +
 			"populated fee and mass")
 	}
 	txID := transaction.TransactionID()
 	txFeeRate := float64(transaction.Transaction().Fee) / float64(transaction.Transaction().Mass)
 
-	return sort.Search(len(tobf.slice), func(i int) bool {
+	index = sort.Search(len(tobf.slice), func(i int) bool {
 		iElement := tobf.slice[i]
 		elementFeeRate := float64(iElement.Transaction().Fee) / float64(iElement.Transaction().Mass)
 		if elementFeeRate > txFeeRate {
@@ -76,5 +75,10 @@ func (tobf *TransactionsOrderedByFeeRate) findTransactionIndex(transaction *Memp
 		}
 
 		return false
-	}), nil
+	})
+
+	wasFound = index != len(tobf.slice) && // sort.Search returns len(tobf.slice) if nothing was found
+		tobf.slice[index].TransactionID().Equal(transaction.TransactionID())
+
+	return index, wasFound, nil
 }

--- a/domain/miningmanager/mempool/model/ordered_transactions_by_fee_rate.go
+++ b/domain/miningmanager/mempool/model/ordered_transactions_by_fee_rate.go
@@ -55,6 +55,9 @@ func (tobf *TransactionsOrderedByFeeRate) RemoveAtIndex(index int) error {
 	return nil
 }
 
+// findTransactionIndex finds the given transaction inside the list of transactions ordered by fee rate.
+// If the transaction was not found, will return wasFound=false and index=the index at which transaction can be inserted
+// while preserving the order.
 func (tobf *TransactionsOrderedByFeeRate) findTransactionIndex(transaction *MempoolTransaction) (index int, wasFound bool, err error) {
 	if transaction.Transaction().Fee == 0 || transaction.Transaction().Mass == 0 {
 		return 0, false, errors.Errorf("findTxIndexInOrderedTransactionsByFeeRate expects a transaction with " +


### PR DESCRIPTION
This PR fixes a new crash caused by calling mempool.RemoveTransaction with a transaction that doesn't exist in the mempool (caused by a non-critical synchronization issue between mempool and consensus).

findTransactionIndex used sort.Search to return the transaction's index. 
If the transaction was not found, it would return `len(transactionsOrderedByFee)`, then when we used the returned index to remove the transaction, an out-of-bounds panic would occur.