### PR TITLE
Improve output of non-critical protocol errors to avoid user panic

### DIFF
--- a/app/protocol/flowcontext/errors.go
+++ b/app/protocol/flowcontext/errors.go
@@ -2,11 +2,17 @@ package flowcontext
 
 import (
 	"errors"
+	"strings"
 	"sync/atomic"
 
 	"github.com/kaspanet/kaspad/infrastructure/network/netadapter/router"
 
 	"github.com/kaspanet/kaspad/app/protocol/protocolerrors"
+)
+
+var (
+	// ErrPingTimeout signifies that a ping operation timed out.
+	ErrPingTimeout = protocolerrors.New(false, "timeout expired on ping")
 )
 
 // HandleError handles an error from a flow,
@@ -21,8 +27,15 @@ func (*FlowContext) HandleError(err error, flowName string, isStopping *uint32, 
 		if protocolErr := (protocolerrors.ProtocolError{}); !errors.As(err, &protocolErr) {
 			panic(err)
 		}
-
-		log.Errorf("error from %s: %+v", flowName, err)
+		if errors.Is(err, ErrPingTimeout) {
+			// Avoid printing the call stack on ping timeouts, since users get panicked and this case is not interesting
+			log.Errorf("error from %s: %s", flowName, err)
+		} else {
+			// Explain to the user that this is not a panic, but only a protocol error with a specific peer
+			logFrame := strings.Repeat("=", 52)
+			log.Errorf("Non-critical peer protocol error from %s, printing the full stack for debug purposes: \n%s\n%+v \n%s",
+				flowName, logFrame, err, logFrame)
+		}
 	}
 
 	if atomic.AddUint32(isStopping, 1) == 1 {

--- a/app/protocol/flows/v4/ping/send.go
+++ b/app/protocol/flows/v4/ping/send.go
@@ -2,6 +2,8 @@ package ping
 
 import (
 	"github.com/kaspanet/kaspad/app/protocol/common"
+	"github.com/kaspanet/kaspad/app/protocol/flowcontext"
+	"github.com/pkg/errors"
 	"time"
 
 	"github.com/kaspanet/kaspad/app/appmessage"
@@ -61,6 +63,9 @@ func (flow *sendPingsFlow) start() error {
 
 		message, err := flow.incomingRoute.DequeueWithTimeout(common.DefaultTimeout)
 		if err != nil {
+			if errors.Is(err, router.ErrTimeout) {
+				return errors.Wrapf(flowcontext.ErrPingTimeout, err.Error())
+			}
 			return err
 		}
 		pongMessage := message.(*appmessage.MsgPong)

--- a/app/protocol/flows/v5/ping/send.go
+++ b/app/protocol/flows/v5/ping/send.go
@@ -2,6 +2,8 @@ package ping
 
 import (
 	"github.com/kaspanet/kaspad/app/protocol/common"
+	"github.com/kaspanet/kaspad/app/protocol/flowcontext"
+	"github.com/pkg/errors"
 	"time"
 
 	"github.com/kaspanet/kaspad/app/appmessage"
@@ -61,6 +63,9 @@ func (flow *sendPingsFlow) start() error {
 
 		message, err := flow.incomingRoute.DequeueWithTimeout(common.DefaultTimeout)
 		if err != nil {
+			if errors.Is(err, router.ErrTimeout) {
+				return errors.Wrapf(flowcontext.ErrPingTimeout, err.Error())
+			}
 			return err
 		}
 		pongMessage := message.(*appmessage.MsgPong)


### PR DESCRIPTION
This PR improves log output. It avoids the full verbose error in the case of ping timeout, and frames the call-stack output in other cases. It looks like this:

2022-03-15 00:45:35.974 [INF] PROT: Non-critical peer protocol error from '', printing the full stack for debug purposes: 
        ====================================================
        timeout expired
        route '' got timeout after 2m0s
        github.com/kaspanet/kaspad/app/protocol/flows/v5/ping.TestPingErr
        	C:/Users/msssu/Documents/Git/kaspanet/kaspad/app/protocol/flows/v5/ping/ping_error_test.go:13
        testing.tRunner
        	C:/Program Files/Go/src/testing/testing.go:1259
        runtime.goexit
        	C:/Program Files/Go/src/runtime/asm_amd64.s:1581 
        ====================================================
