### PR TITLE
Add names to nameless routes

### DIFF
--- a/infrastructure/network/netadapter/netadapter.go
+++ b/infrastructure/network/netadapter/netadapter.go
@@ -128,7 +128,7 @@ func (na *NetAdapter) P2PConnectionCount() int {
 }
 
 func (na *NetAdapter) onP2PConnectedHandler(connection server.Connection) error {
-	netConnection := newNetConnection(connection, na.p2pRouterInitializer)
+	netConnection := newNetConnection(connection, na.p2pRouterInitializer, "on P2P connected")
 
 	na.p2pConnectionsLock.Lock()
 	defer na.p2pConnectionsLock.Unlock()
@@ -148,7 +148,7 @@ func (na *NetAdapter) onP2PConnectedHandler(connection server.Connection) error 
 }
 
 func (na *NetAdapter) onRPCConnectedHandler(connection server.Connection) error {
-	netConnection := newNetConnection(connection, na.rpcRouterInitializer)
+	netConnection := newNetConnection(connection, na.rpcRouterInitializer, "on RPC connected")
 	netConnection.setOnDisconnectedHandler(func() {})
 	netConnection.start()
 

--- a/infrastructure/network/netadapter/netconnection.go
+++ b/infrastructure/network/netadapter/netconnection.go
@@ -20,8 +20,8 @@ type NetConnection struct {
 	isRouterClosed        uint32
 }
 
-func newNetConnection(connection server.Connection, routerInitializer RouterInitializer) *NetConnection {
-	router := routerpkg.NewRouter()
+func newNetConnection(connection server.Connection, routerInitializer RouterInitializer, name string) *NetConnection {
+	router := routerpkg.NewRouter(name)
 
 	netConnection := &NetConnection{
 		connection: connection,

--- a/infrastructure/network/netadapter/router/router.go
+++ b/infrastructure/network/netadapter/router/router.go
@@ -24,10 +24,10 @@ type Router struct {
 }
 
 // NewRouter creates a new empty router
-func NewRouter() *Router {
+func NewRouter(name string) *Router {
 	router := Router{
 		incomingRoutes: make(map[appmessage.MessageCommand]*Route),
-		outgoingRoute:  newRouteWithCapacity("", outgoingRouteMaxMessages),
+		outgoingRoute:  newRouteWithCapacity(name, outgoingRouteMaxMessages),
 	}
 	return &router
 }

--- a/infrastructure/network/rpcclient/rpcrouter.go
+++ b/infrastructure/network/rpcclient/rpcrouter.go
@@ -11,7 +11,7 @@ type rpcRouter struct {
 }
 
 func buildRPCRouter() (*rpcRouter, error) {
-	router := routerpkg.NewRouter()
+	router := routerpkg.NewRouter("RPC server")
 	routes := make(map[appmessage.MessageCommand]*routerpkg.Route, len(appmessage.RPCMessageCommandToString))
 	for messageType := range appmessage.RPCMessageCommandToString {
 		route, err := router.AddIncomingRoute("rpc client", []appmessage.MessageCommand{messageType})


### PR DESCRIPTION
Adding names to nameless routes of capacity of 131172 to avoid messages like "route '' reached capacity of 131172" where it's unclear what exactly this route is.