### PR TITLE
Cache the pruning point anticone

### DIFF
--- a/domain/migrate.go
+++ b/domain/migrate.go
@@ -11,6 +11,7 @@ func (d *domain) migrate() error {
 	if err != nil {
 		return err
 	}
+	log.Infof("Current pruning point: %s", pruningPoint)
 
 	if d.consensusConfig.Params.GenesisHash.Equal(pruningPoint) {
 		err = d.initStagingConsensus(d.consensusConfig)


### PR DESCRIPTION
Current running nodes might freeze for a moment when syncing nodes ask them for the pruning point anticone. This PR adds a simple cache so that the freeze happens only once a day  