### PR TITLE
Add DB compaction after the deletion of a DB prefix

### DIFF
--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -935,7 +935,7 @@ func (pm *pruningManager) PruningPointAndItsAnticone() ([]*externalapi.DomainHas
 		return nil, err
 	}
 
-	// By the Prunality proof, The pruning point anticone is a closed set (i.e., guaranteed not to change) ,
+	// By the Prunality proof, the pruning point anticone is a closed set (i.e., guaranteed not to change) ,
 	// so we can safely cache it.
 	if pm.cachedPruningPoint != nil && pm.cachedPruningPoint.Equal(pruningPoint) {
 		return append([]*externalapi.DomainHash{pruningPoint}, pm.cachedPruningPointAnticone...), nil

--- a/infrastructure/db/database/database.go
+++ b/infrastructure/db/database/database.go
@@ -14,6 +14,9 @@ type Database interface {
 	// Begin begins a new database transaction.
 	Begin() (Transaction, error)
 
+	// Compact compacts the database instance.
+	Compact() error
+
 	// Close closes the database.
 	Close() error
 }

--- a/infrastructure/db/database/ldb/leveldb.go
+++ b/infrastructure/db/database/ldb/leveldb.go
@@ -6,6 +6,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 	ldbErrors "github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 // LevelDB defines a thin wrapper around leveldb.
@@ -45,6 +46,12 @@ func NewLevelDB(path string, cacheSizeMiB int) (*LevelDB, error) {
 		ldb: ldb,
 	}
 	return db, nil
+}
+
+// Compact compacts the leveldb instance.
+func (db *LevelDB) Compact() error {
+	err := db.ldb.CompactRange(util.Range{Start: nil, Limit: nil})
+	return errors.WithStack(err)
 }
 
 // Close closes the leveldb instance.


### PR DESCRIPTION
Apparently LevelDB does not necessarily compact data following a large delete operation, but rather marks items as deleted, which at times might increase DB size, until a compaction is triggered. 

Since DB size effects performance even if disk has sufficient space, it makes sense to explicitly call `Compact` whenever we delete a whole DB prefix. 

Specifically, this will help nodes using `migrate` to reduce DB size following the migration.  