### PR TITLE
Prevent memory leaking in binaryserializer and domainhash

### DIFF
--- a/domain/consensus/model/externalapi/hash.go
+++ b/domain/consensus/model/externalapi/hash.go
@@ -65,16 +65,13 @@ func (hash DomainHash) String() string {
 }
 
 // ByteArray returns the bytes in this hash represented as a byte array.
-// The hash bytes are cloned, therefore it is safe to modify the resulting array.
 func (hash *DomainHash) ByteArray() *[DomainHashSize]byte {
-	arrayClone := hash.hashArray
-	return &arrayClone
+	return &hash.hashArray
 }
 
 // ByteSlice returns the bytes in this hash represented as a byte slice.
-// The hash bytes are cloned, therefore it is safe to modify the resulting slice.
 func (hash *DomainHash) ByteSlice() []byte {
-	return hash.ByteArray()[:]
+	return hash.hashArray[:]
 }
 
 // If this doesn't compile, it means the type definition has been changed, so it's

--- a/util/binaryserializer/binaryserializer.go
+++ b/util/binaryserializer/binaryserializer.go
@@ -113,9 +113,10 @@ func PutUint16(w io.Writer, val uint16) error {
 // buffer from the free list and writes the resulting four bytes to the given
 // writer.
 func PutUint32(w io.Writer, val uint32) error {
-	var buf [4]byte
-	binary.LittleEndian.PutUint32(buf[:], val)
-	_, err := w.Write(buf[:])
+	buf := Borrow()[:4]
+	binary.LittleEndian.PutUint32(buf, val)
+	_, err := w.Write(buf)
+	Return(buf)
 	return errors.WithStack(err)
 }
 
@@ -123,9 +124,10 @@ func PutUint32(w io.Writer, val uint32) error {
 // buffer from the free list and writes the resulting eight bytes to the given
 // writer.
 func PutUint64(w io.Writer, val uint64) error {
-	var buf [8]byte
-	binary.LittleEndian.PutUint64(buf[:], val)
-	_, err := w.Write(buf[:])
+	buf := Borrow()[:8]
+	binary.LittleEndian.PutUint64(buf, val)
+	_, err := w.Write(buf)
+	Return(buf)
 	return errors.WithStack(err)
 }
 


### PR DESCRIPTION
ByteSlice() needs some extra checking