### PR TITLE
Kaspawallet: track utxos / transactions - stop wallet from reusing spent utxos.

### DIFF
--- a/btcd/addrmanager_test.go
+++ b/btcd/addrmanager_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2013 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/conformal/btcwire"
+	"net"
+	"testing"
+	"time"
+)
+
+// naTest is used to describe a test to be perfomed against the NetAddressKey
+// method.
+type naTest struct {
+	in   btcwire.NetAddress
+	want string
+}
+
+// naTests houses all of the tests to be performed against the NetAddressKey
+// method.
+var naTests = make([]naTest, 0)
+
+func addNaTest(ip string, port uint16, want string) {
+	nip := net.ParseIP(ip)
+	na := btcwire.NetAddress{
+		Timestamp: time.Now(),
+		Services:  btcwire.SFNodeNetwork,
+		IP:        nip,
+		Port:      port,
+	}
+	test := naTest{na, want}
+	naTests = append(naTests, test)
+}
+
+// addNaTests
+func addNaTests() {
+	// IPv4
+	// Localhost
+	addNaTest("127.0.0.1", 8333, "127.0.0.1:8333")
+	addNaTest("127.0.0.1", 8334, "127.0.0.1:8334")
+
+	// Class A
+	addNaTest("1.0.0.1", 8333, "1.0.0.1:8333")
+	addNaTest("2.2.2.2", 8334, "2.2.2.2:8334")
+	addNaTest("27.253.252.251", 8335, "27.253.252.251:8335")
+	addNaTest("123.3.2.1", 8336, "123.3.2.1:8336")
+
+	// Private Class A
+	addNaTest("10.0.0.1", 8333, "10.0.0.1:8333")
+	addNaTest("10.1.1.1", 8334, "10.1.1.1:8334")
+	addNaTest("10.2.2.2", 8335, "10.2.2.2:8335")
+	addNaTest("10.10.10.10", 8336, "10.10.10.10:8336")
+
+	// Class B
+	addNaTest("128.0.0.1", 8333, "128.0.0.1:8333")
+	addNaTest("129.1.1.1", 8334, "129.1.1.1:8334")
+	addNaTest("180.2.2.2", 8335, "180.2.2.2:8335")
+	addNaTest("191.10.10.10", 8336, "191.10.10.10:8336")
+
+	// Private Class B
+	addNaTest("172.16.0.1", 8333, "172.16.0.1:8333")
+	addNaTest("172.16.1.1", 8334, "172.16.1.1:8334")
+	addNaTest("172.16.2.2", 8335, "172.16.2.2:8335")
+	addNaTest("172.16.172.172", 8336, "172.16.172.172:8336")
+
+	// Class C
+	addNaTest("193.0.0.1", 8333, "193.0.0.1:8333")
+	addNaTest("200.1.1.1", 8334, "200.1.1.1:8334")
+	addNaTest("205.2.2.2", 8335, "205.2.2.2:8335")
+	addNaTest("223.10.10.10", 8336, "223.10.10.10:8336")
+
+	// Private Class C
+	addNaTest("192.168.0.1", 8333, "192.168.0.1:8333")
+	addNaTest("192.168.1.1", 8334, "192.168.1.1:8334")
+	addNaTest("192.168.2.2", 8335, "192.168.2.2:8335")
+	addNaTest("192.168.192.192", 8336, "192.168.192.192:8336")
+
+	// IPv6
+	// Localhost
+	addNaTest("::1", 8333, "[::1]:8333")
+	addNaTest("fe80::1", 8334, "[fe80::1]:8334")
+
+	// Link-local
+	addNaTest("fe80::1:1", 8333, "[fe80::1:1]:8333")
+	addNaTest("fe91::2:2", 8334, "[fe91::2:2]:8334")
+	addNaTest("fea2::3:3", 8335, "[fea2::3:3]:8335")
+	addNaTest("feb3::4:4", 8336, "[feb3::4:4]:8336")
+
+	// Site-local
+	addNaTest("fec0::1:1", 8333, "[fec0::1:1]:8333")
+	addNaTest("fed1::2:2", 8334, "[fed1::2:2]:8334")
+	addNaTest("fee2::3:3", 8335, "[fee2::3:3]:8335")
+	addNaTest("fef3::4:4", 8336, "[fef3::4:4]:8336")
+}
+
+func TestNetAddressKey(t *testing.T) {
+	addNaTests()
+
+	t.Logf("Running %d tests", len(naTests))
+	for i, test := range naTests {
+		key := NetAddressKey(&test.in)
+		if key != test.want {
+			t.Errorf("NetAddressKey #%d\n got: %s want: %s", i, key, test.want)
+			continue
+		}
+	}
+}

--- a/btcd/config.go
+++ b/btcd/config.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2013 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/conformal/btcwire"
+	"github.com/conformal/go-flags"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	defaultConfigFilename = "btcd.conf"
+	defaultLogLevel       = "info"
+	defaultBtcnet         = btcwire.MainNet
+	defaultMaxPeers       = 8
+	defaultBanDuration    = time.Hour * 24
+	defaultVerifyEnabled  = false
+)
+
+var (
+	defaultConfigFile = filepath.Join(btcdHomeDir(), defaultConfigFilename)
+	defaultDbDir      = filepath.Join(btcdHomeDir(), "db")
+)
+
+// config defines the configuration options for btcd.
+//
+// See loadConfig for details on the configuration load process.
+type config struct {
+	DebugLevel     string        `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
+	AddPeers       []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
+	ConnectPeers   []string      `long:"connect" description:"Connect only to the specified peers at startup"`
+	SeedPeer       string        `short:"s" long:"seedpeer" description:"Retrieve peer addresses from this peer and then disconnect"`
+	Port           string        `short:"p" long:"port" description:"Listen for connections on this port (default: 8333, testnet: 18333)"`
+	RpcPort        string        `short:"r" long:"rpcport" description:"Listen for json/rpc messages on this port"`
+	MaxPeers       int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
+	BanDuration    time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
+	VerifyDisabled bool          `long:"noverify" description:"Disable block/transaction verification -- WARNING: This option can be dangerous and is for development use only"`
+	ConfigFile     string        `short:"C" long:"configfile" description:"Path to configuration file"`
+	DbDir          string        `short:"b" long:"dbdir" description:"Directory to store database"`
+	RpcUser        string        `short:"u" long:"rpcuser" description:"Username for rpc connections"`
+	RpcPass        string        `short:"P" long:"rpcpass" description:"Password for rpc connections"`
+	DisableRpc     bool          `long:"norpc" description:"Disable built-in RPC server"`
+	DisableDNSSeed bool          `long:"nodnsseed" description:"Disable DNS seeding for peers"`
+	TestNet3       bool          `long:"testnet" description:"Use the test network"`
+	RegressionTest bool          `long:"regtest" description:"Use the regression test network"`
+}
+
+// btcdHomeDir returns an OS appropriate home directory for btcd.
+func btcdHomeDir() string {
+	// Search for Windows APPDATA first.  This won't exist on POSIX OSes.
+	appData := os.Getenv("APPDATA")
+	if appData != "" {
+		return filepath.Join(appData, "btcd")
+	}
+
+	// Fall back to standard HOME directory that works for most POSIX OSes.
+	home := os.Getenv("HOME")
+	if home != "" {
+		return filepath.Join(home, ".btcd")
+	}
+
+	// In the worst case, use the current directory.
+	return "."
+}
+
+// validLogLevel returns whether or not logLevel is a valid debug log level.
+func validLogLevel(logLevel string) bool {
+	switch logLevel {
+	case "trace":
+		fallthrough
+	case "debug":
+		fallthrough
+	case "info":
+		fallthrough
+	case "warn":
+		fallthrough
+	case "error":
+		fallthrough
+	case "critical":
+		return true
+	}
+	return false
+}
+
+// normalizePeerAddress returns addr with the default peer port appended if
+// there is not already a port specified.
+func normalizePeerAddress(addr string) string {
+	_, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return net.JoinHostPort(addr, activeNetParams.peerPort)
+	}
+	return addr
+}
+
+// removeDuplicateAddresses returns a new slice with all duplicate entries in
+// addrs removed.
+func removeDuplicateAddresses(addrs []string) []string {
+	result := make([]string, 0)
+	seen := map[string]bool{}
+	for _, val := range addrs {
+		if _, ok := seen[val]; !ok {
+			result = append(result, val)
+			seen[val] = true
+		}
+	}
+	return result
+}
+
+func normalizeAndRemoveDuplicateAddresses(addrs []string) []string {
+	for i, addr := range addrs {
+		addrs[i] = normalizePeerAddress(addr)
+	}
+	addrs = removeDuplicateAddresses(addrs)
+
+	return addrs
+}
+
+// updateConfigWithActiveParams update the passed config with parameters
+// from the active net params if the relevant options in the passed config
+// object are the default so options specified by the user on the command line
+// are not overridden.
+func updateConfigWithActiveParams(cfg *config) {
+	if cfg.Port == netParams(defaultBtcnet).listenPort {
+		cfg.Port = activeNetParams.listenPort
+	}
+
+	if cfg.RpcPort == netParams(defaultBtcnet).rpcPort {
+		cfg.RpcPort = activeNetParams.rpcPort
+	}
+}
+
+// filesExists reports whether the named file or directory exists.
+func fileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
+// loadConfig initializes and parses the config using a config file and command
+// line options.
+//
+// The configuration proceeds as follows:
+// 	1) Start with a default config with sane settings
+// 	2) Pre-parse the command line to check for an alternative config file
+// 	3) Load configuration file overwriting defaults with any specified options
+// 	4) Parse CLI options and overwrite/add any specified options
+//
+// The above results in btcd functioning properly without any config settings
+// while still allowing the user to override settings with config files and
+// command line options.  Command line options always take precedence.
+func loadConfig() (*config, []string, error) {
+	// Default config.
+	cfg := config{
+		DebugLevel:  defaultLogLevel,
+		Port:        netParams(defaultBtcnet).listenPort,
+		RpcPort:     netParams(defaultBtcnet).rpcPort,
+		MaxPeers:    defaultMaxPeers,
+		BanDuration: defaultBanDuration,
+		ConfigFile:  defaultConfigFile,
+		DbDir:       defaultDbDir,
+	}
+
+	// A config file in the current directory takes precedence.
+	if fileExists(defaultConfigFilename) {
+		cfg.ConfigFile = defaultConfigFilename
+	}
+
+	// Pre-parse the command line options to see if an alternative config
+	// file was specified.
+	preCfg := cfg
+	preParser := flags.NewParser(&preCfg, flags.Default)
+	_, err := preParser.Parse()
+	if err != nil {
+		if e, ok := err.(*flags.Error); !ok || e.Type != flags.ErrHelp {
+			preParser.WriteHelp(os.Stderr)
+		}
+		return nil, nil, err
+	}
+
+	// Load additional config from file.
+	parser := flags.NewParser(&cfg, flags.Default)
+	err = parser.ParseIniFile(preCfg.ConfigFile)
+	if err != nil {
+		if _, ok := err.(*os.PathError); !ok {
+			fmt.Fprintln(os.Stderr, err)
+			parser.WriteHelp(os.Stderr)
+			return nil, nil, err
+		}
+		log.Warnf("%v", err)
+	}
+
+	// Parse command line options again to ensure they take precedence.
+	remainingArgs, err := parser.Parse()
+	if err != nil {
+		if e, ok := err.(*flags.Error); !ok || e.Type != flags.ErrHelp {
+			parser.WriteHelp(os.Stderr)
+		}
+		return nil, nil, err
+	}
+
+	// The two test networks can't be selected simultaneously.
+	if cfg.TestNet3 && cfg.RegressionTest {
+		str := "%s: The testnet and regtest params can't be used " +
+			"together -- choose one of the two"
+		err := errors.New(fmt.Sprintf(str, "loadConfig"))
+		fmt.Fprintln(os.Stderr, err)
+		parser.WriteHelp(os.Stderr)
+		return nil, nil, err
+	}
+
+	// Choose the active network params based on the testnet and regression
+	// test net flags.
+	if cfg.TestNet3 {
+		activeNetParams = netParams(btcwire.TestNet3)
+	} else if cfg.RegressionTest {
+		activeNetParams = netParams(btcwire.TestNet)
+	}
+	updateConfigWithActiveParams(&cfg)
+
+	// Validate debug log level.
+	if !validLogLevel(cfg.DebugLevel) {
+		str := "%s: The specified debug level is invalid -- parsed [%v]"
+		err := errors.New(fmt.Sprintf(str, "loadConfig", cfg.DebugLevel))
+		fmt.Fprintln(os.Stderr, err)
+		parser.WriteHelp(os.Stderr)
+		return nil, nil, err
+	}
+
+	// Don't allow ban durations that are too short.
+	if cfg.BanDuration < time.Duration(time.Second) {
+		str := "%s: The banduration option may not be less than 1s -- parsed [%v]"
+		err := errors.New(fmt.Sprintf(str, "loadConfig", cfg.BanDuration))
+		fmt.Fprintln(os.Stderr, err)
+		parser.WriteHelp(os.Stderr)
+		return nil, nil, err
+	}
+
+	// --addPeer and --connect do not mix.
+	if len(cfg.AddPeers) > 0 && len(cfg.ConnectPeers) > 0 {
+		str := "%s: the --addpeer and --connect options can not be " +
+			"mixed"
+		err := errors.New(fmt.Sprintf(str, "loadConfig"))
+		fmt.Fprintln(os.Stderr, err)
+		parser.WriteHelp(os.Stderr)
+		return nil, nil, err
+	}
+
+	// Connect means no seeding or listening.
+	if len(cfg.ConnectPeers) > 0 {
+		cfg.DisableDNSSeed = true
+		// XXX turn off server listening.
+	}
+
+	// Add default port to all added peer addresses if needed and remove
+	// duplicate addresses.
+	cfg.AddPeers = normalizeAndRemoveDuplicateAddresses(cfg.AddPeers)
+	cfg.ConnectPeers =
+		normalizeAndRemoveDuplicateAddresses(cfg.ConnectPeers)
+
+	return &cfg, remainingArgs, nil
+}

--- a/btcd/peer.go
+++ b/btcd/peer.go
@@ -1,0 +1,751 @@
+// Copyright (c) 2013 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"github.com/conformal/btcdb"
+	"github.com/conformal/btcutil"
+	"github.com/conformal/btcwire"
+	"github.com/davecgh/go-spew/spew"
+	"net"
+	"sync"
+	"time"
+)
+
+const outputBufferSize = 50
+
+// zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
+var zeroHash btcwire.ShaHash
+
+// minUint32 is a helper function to return the minimum of two uint32s.
+// This avoids a math import and the need to cast to floats.
+func minUint32(a, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// peer provides a bitcoin peer for handling bitcoin communications.
+type peer struct {
+	server          *server
+	protocolVersion uint32
+	btcnet          btcwire.BitcoinNet
+	services        btcwire.ServiceFlag
+	started         bool
+	conn            net.Conn
+	timeConnected   time.Time
+	inbound         bool
+	disconnect      bool
+	persistent      bool
+	versionKnown    bool
+	knownAddresses  map[string]bool
+	lastBlock       int32
+	wg              sync.WaitGroup
+	outputQueue     chan btcwire.Message
+	quit            chan bool
+}
+
+// pushVersionMsg sends a version message to the connected peer using the
+// current state.
+func (p *peer) pushVersionMsg() error {
+	_, blockNum, err := p.server.db.NewestSha()
+	if err != nil {
+		return err
+	}
+
+	msg, err := btcwire.NewMsgVersionFromConn(p.conn, p.server.nonce,
+		userAgent, int32(blockNum))
+	if err != nil {
+		return err
+	}
+
+	// XXX: bitcoind appears to always enable the full node services flag
+	// of the remote peer netaddress field in the version message regardless
+	// of whether it knows it supports it or not.  Also, bitcoind sets
+	// the services field of the local peer to 0 regardless of support.
+	//
+	// Realistically, this should be set as follows:
+	// - For outgoing connections:
+	//    - Set the local netaddress services to what the local peer
+	//      actually supports
+	//    - Set the remote netaddress services to 0 to indicate no services
+	//      as they are still unknown
+	// - For incoming connections:
+	//    - Set the local netaddress services to what the local peer
+	//      actually supports
+	//    - Set the remote netaddress services to the what was advertised by
+	//      by the remote peer in its version message
+	msg.AddrYou.Services = btcwire.SFNodeNetwork
+
+	// Advertise that we're a full node.
+	msg.Services = btcwire.SFNodeNetwork
+
+	p.outputQueue <- msg
+	return nil
+}
+
+// handleVersionMsg is invoked when a peer receives a version bitcoin message
+// and is used to negotiate the protocol version details as well as kick start
+// the communications.
+func (p *peer) handleVersionMsg(msg *btcwire.MsgVersion) {
+	// Detect self connections.
+	if msg.Nonce == p.server.nonce {
+		log.Debugf("[PEER] Disconnecting peer connected to self %s",
+			p.conn.RemoteAddr())
+		p.disconnect = true
+		p.conn.Close()
+		return
+	}
+
+	// Limit to one version message per peer.
+	if p.versionKnown {
+		log.Errorf("[PEER] Only one version message per peer is allowed %s.",
+			p.conn.RemoteAddr())
+		p.disconnect = true
+		p.conn.Close()
+		return
+	}
+
+	// Negotiate the protocol version.
+	p.protocolVersion = minUint32(p.protocolVersion, uint32(msg.ProtocolVersion))
+	p.versionKnown = true
+	log.Debugf("[PEER] Negotiated protocol version %d for peer %s",
+		p.protocolVersion, p.conn.RemoteAddr())
+	p.lastBlock = msg.LastBlock
+
+	// Inbound connections.
+	if p.inbound {
+		// Set the supported services for the peer to what the remote
+		// peer advertised.
+		p.services = msg.Services
+
+		// Send version.
+		err := p.pushVersionMsg()
+		if err != nil {
+			log.Errorf("[PEER] %v", err)
+			p.disconnect = true
+			p.conn.Close()
+			return
+		}
+
+		// Add inbound peer address to the server address manager.
+		na, err := btcwire.NewNetAddress(p.conn.RemoteAddr(), p.services)
+		if err != nil {
+			log.Errorf("[PEER] %v", err)
+			p.disconnect = true
+			p.conn.Close()
+			return
+		}
+		p.server.addrManager.AddAddress(na)
+	}
+
+	// Send verack.
+	p.outputQueue <- btcwire.NewMsgVerAck()
+
+	// Outbound connections.
+	if !p.inbound {
+		// TODO: Only do this if we're listening, not doing the initial
+		// block download, and are routable.
+		// Advertise the local address.
+		na, err := btcwire.NewNetAddress(p.conn.LocalAddr(), p.services)
+		if err != nil {
+			log.Errorf("[PEER] %v", err)
+			p.disconnect = true
+			p.conn.Close()
+			return
+		}
+		na.Services = p.services
+		addresses := map[string]*btcwire.NetAddress{
+			NetAddressKey(na): na,
+		}
+		p.pushAddrMsg(addresses)
+
+		// Request known addresses if the server address manager needs
+		// more and the peer has a protocol version new enough to
+		// include a timestamp with addresses.
+		hasTimestamp := p.protocolVersion >= btcwire.NetAddressTimeVersion
+		if p.server.addrManager.NeedMoreAddresses() && hasTimestamp {
+			p.outputQueue <- btcwire.NewMsgGetAddr()
+		}
+	}
+
+	// Request latest blocks if the peer has blocks we're interested in.
+	// XXX: Ask block manager for latest so we get in-flight too...
+	sha, lastBlock, err := p.server.db.NewestSha()
+	if err != nil {
+		log.Errorf("[PEER] %v", err)
+		p.disconnect = true
+		p.conn.Close()
+	}
+	// If the peer has blocks we're interested in.
+	if p.lastBlock > int32(lastBlock) {
+		stopHash := btcwire.ShaHash{}
+		gbmsg := btcwire.NewMsgGetBlocks(&stopHash)
+		p.server.blockManager.AddBlockLocators(sha, gbmsg)
+		p.outputQueue <- gbmsg
+	}
+
+	// TODO: Relay alerts.
+}
+
+// pushTxMsg sends a tx message for the provided transaction hash to the
+// connected peer.  An error is returned if the transaction sha is not known.
+func (p *peer) pushTxMsg(sha btcwire.ShaHash) error {
+	// We dont deal with these for now.
+	return errors.New("Tx fetching not implemented")
+}
+
+// pushBlockMsg sends a block message for the provided block hash to the
+// connected peer.  An error is returned if the block hash is not known.
+func (p *peer) pushBlockMsg(sha btcwire.ShaHash) error {
+	// What should this function do about the rate limiting the
+	// number of blocks queued for this peer?
+	// Current thought is have a counting mutex in the peer
+	// such that if > N Tx/Block requests are currently in
+	// the tx queue, wait until the mutex clears allowing more to be
+	// sent. This prevents 500 1+MB blocks from being loaded into
+	// memory and sit around until the output queue drains.
+	// Actually the outputQueue has a limit of 50 in its queue
+	// but still 50MB to 1.6GB(50 32MB blocks) just setting
+	// in memory waiting to be sent is pointless.
+	// I would recommend a getdata request limit of about 5
+	// outstanding objects.
+	// Should the tx complete api be a mutex or channel?
+
+	blk, err := p.server.db.FetchBlockBySha(&sha)
+	if err != nil {
+		log.Tracef("[PEER] Unable to fetch requested block sha %v: %v",
+			&sha, err)
+		return err
+	}
+	p.QueueMessage(blk.MsgBlock())
+	return nil
+}
+
+// handleGetData is invoked when a peer receives a getdata bitcoin message and
+// is used to deliver block and transaction information.
+func (p *peer) handleGetDataMsg(msg *btcwire.MsgGetData) {
+	notFound := btcwire.NewMsgNotFound()
+
+out:
+	for _, iv := range msg.InvList {
+		var err error
+		switch iv.Type {
+		case btcwire.InvVect_Tx:
+			err = p.pushTxMsg(iv.Hash)
+		case btcwire.InvVect_Block:
+			err = p.pushBlockMsg(iv.Hash)
+		default:
+			log.Warnf("[PEER] Unknown type in inventory request %d",
+				iv.Type)
+			break out
+		}
+		if err != nil {
+			notFound.AddInvVect(iv)
+		}
+	}
+	if len(notFound.InvList) != 0 {
+		p.QueueMessage(notFound)
+	}
+}
+
+// handleGetBlocksMsg is invoked when a peer receives a getdata bitcoin message.
+func (p *peer) handleGetBlocksMsg(msg *btcwire.MsgGetBlocks) {
+	var err error
+	startIdx := int64(0)
+	endIdx := btcdb.AllShas
+
+	// Return all block hashes to the latest one (up to max per message) if
+	// no stop hash was specified.
+	// Attempt to find the ending index of the stop hash if specified.
+	if !msg.HashStop.IsEqual(&zeroHash) {
+		block, err := p.server.db.FetchBlockBySha(&msg.HashStop)
+		if err != nil {
+			// Fetch all if we dont recognize the stop hash.
+			endIdx = btcdb.AllShas
+		}
+		endIdx = block.Height()
+	}
+
+	// TODO(davec): This should have some logic to utilize the additional
+	// locator hashes to ensure the proper chain.
+	for _, hash := range msg.BlockLocatorHashes {
+		// TODO(drahn) does using the caching interface make sense
+		// on index lookups ?
+		block, err := p.server.db.FetchBlockBySha(hash)
+		if err == nil {
+			// Start with the next hash since we know this one.
+			startIdx = block.Height() + 1
+			break
+		}
+	}
+
+	// Don't attempt to fetch more than we can put into a single message.
+	if endIdx-startIdx > btcwire.MaxInvPerMsg {
+		endIdx = startIdx + btcwire.MaxInvPerMsg
+	}
+
+	// Fetch the inventory from the block database.
+	hashList, err := p.server.db.FetchHeightRange(startIdx, endIdx)
+	if err != nil {
+		log.Warnf(" lookup returned %v ", err)
+		return
+	}
+
+	// Nothing to send.
+	if len(hashList) == 0 {
+		return
+	}
+
+	// Generate inventory vectors and push the inventory message.
+	inv := btcwire.NewMsgInv()
+	for _, hash := range hashList {
+		iv := btcwire.InvVect{Type: btcwire.InvVect_Block, Hash: hash}
+		inv.AddInvVect(&iv)
+	}
+	p.QueueMessage(inv)
+}
+
+// handleGetBlocksMsg is invoked when a peer receives a getheaders bitcoin
+// message.
+func (p *peer) handleGetHeadersMsg(msg *btcwire.MsgGetHeaders) {
+	var err error
+	startIdx := int64(0)
+	endIdx := btcdb.AllShas
+
+	// Return all block hashes to the latest one (up to max per message) if
+	// no stop hash was specified.
+	// Attempt to find the ending index of the stop hash if specified.
+	if !msg.HashStop.IsEqual(&zeroHash) {
+		block, err := p.server.db.FetchBlockBySha(&msg.HashStop)
+		if err != nil {
+			// Fetch all if we dont recognize the stop hash.
+			endIdx = btcdb.AllShas
+		}
+		endIdx = block.Height()
+	}
+
+	// TODO(davec): This should have some logic to utilize the additional
+	// locator hashes to ensure the proper chain.
+	for _, hash := range msg.BlockLocatorHashes {
+		// TODO(drahn) does using the caching interface make sense
+		// on index lookups ?
+		block, err := p.server.db.FetchBlockBySha(hash)
+		if err == nil {
+			// Start with the next hash since we know this one.
+			startIdx = block.Height() + 1
+			break
+		}
+	}
+
+	// Don't attempt to fetch more than we can put into a single message.
+	if endIdx-startIdx > btcwire.MaxBlockHeadersPerMsg {
+		endIdx = startIdx + btcwire.MaxBlockHeadersPerMsg
+	}
+
+	// Fetch the inventory from the block database.
+	hashList, err := p.server.db.FetchHeightRange(startIdx, endIdx)
+	if err != nil {
+		log.Warnf("lookup returned %v ", err)
+		return
+	}
+
+	// Nothing to send.
+	if len(hashList) == 0 {
+		return
+	}
+
+	// Generate inventory vectors and push the inventory message.
+	headersMsg := btcwire.NewMsgHeaders()
+	for _, hash := range hashList {
+		block, err := p.server.db.FetchBlockBySha(&hash)
+		if err != nil {
+			log.Warnf("[PEER] badness %v", err)
+		}
+		hdr := block.MsgBlock().Header // copy
+		hdr.TxnCount = 0
+		headersMsg.AddBlockHeader(&hdr)
+	}
+	p.QueueMessage(headersMsg)
+}
+
+// handleGetAddrMsg is invoked when a peer receives a getaddr bitcoin message
+// and is used to provide the peer with known addresses from the address
+// manager.
+func (p *peer) handleGetAddrMsg(msg *btcwire.MsgGetAddr) {
+	// Get the current known addresses from the address manager.
+	addrCache := p.server.addrManager.AddressCache()
+
+	// Push the addresses.
+	err := p.pushAddrMsg(addrCache)
+	if err != nil {
+		log.Errorf("[PEER] %v", err)
+		p.disconnect = true
+		p.conn.Close()
+		return
+	}
+}
+
+// pushAddrMsg sends one, or more, addr message(s) to the connected peer using
+// the provided addresses.
+func (p *peer) pushAddrMsg(addresses map[string]*btcwire.NetAddress) error {
+	// Nothing to send.
+	if len(addresses) == 0 {
+		return nil
+	}
+
+	numAdded := 0
+	msg := btcwire.NewMsgAddr()
+	for _, na := range addresses {
+		// Filter addresses the peer already knows about.
+		if p.knownAddresses[NetAddressKey(na)] {
+			continue
+		}
+
+		// Add the address to the message.
+		err := msg.AddAddress(na)
+		if err != nil {
+			return err
+		}
+		numAdded++
+
+		// Split into multiple messages as needed.
+		if numAdded > 0 && numAdded%btcwire.MaxAddrPerMsg == 0 {
+			p.outputQueue <- msg
+			msg.ClearAddresses()
+		}
+	}
+
+	// Send message with remaining addresses if needed.
+	if numAdded%btcwire.MaxAddrPerMsg != 0 {
+		p.outputQueue <- msg
+	}
+	return nil
+}
+
+// handleAddrMsg is invoked when a peer receives an addr bitcoin message and
+// is used to notify the server about advertised addresses.
+func (p *peer) handleAddrMsg(msg *btcwire.MsgAddr) {
+	// Ignore old style addresses which don't include a timestamp.
+	if p.protocolVersion < btcwire.NetAddressTimeVersion {
+		return
+	}
+
+	// A message that has no addresses is invalid.
+	if len(msg.AddrList) == 0 {
+		log.Errorf("[PEER] Command [%s] from %s does not contain any addresses",
+			msg.Command(), p.conn.RemoteAddr())
+		p.disconnect = true
+		p.conn.Close()
+		return
+	}
+
+	for _, na := range msg.AddrList {
+		// Don't add more address if we're disconnecting.
+		if p.disconnect {
+			return
+		}
+
+		// Set the timestamp to 5 days ago if it's more than 24 hours
+		// in the future so this address is one of the first to be
+		// removed when space is needed.
+		now := time.Now()
+		if na.Timestamp.After(now.Add(time.Minute * 10)) {
+			na.Timestamp = now.Add(-1 * time.Hour * 24 * 5)
+		}
+
+		// Add address to known addresses for this peer.
+		p.knownAddresses[NetAddressKey(na)] = true
+	}
+
+	// Add addresses to server address manager.  The address manager handles
+	// the details of things such as preventing duplicate addresses, max
+	// addresses, and last seen updates.
+	p.server.addrManager.AddAddresses(msg.AddrList)
+}
+
+// handlePingMsg is invoked when a peer receives a ping bitcoin message.  For
+// recent clients (protocol version > BIP0031Version), it replies with a pong
+// message.  For older clients, it does nothing and anything other than failure
+// is considered a successful ping.
+func (p *peer) handlePingMsg(msg *btcwire.MsgPing) {
+	// Only Reply with pong is message comes from a new enough client.
+	if p.protocolVersion > btcwire.BIP0031Version {
+		// Include nonce from ping so pong can be identified.
+		p.outputQueue <- btcwire.NewMsgPong(msg.Nonce)
+	}
+}
+
+// readMessage reads the next bitcoin message from the peer with logging.
+func (p *peer) readMessage() (msg btcwire.Message, buf []byte, err error) {
+	msg, buf, err = btcwire.ReadMessage(p.conn, p.protocolVersion, p.btcnet)
+	if err != nil {
+		return
+	}
+	log.Debugf("[PEER] Received command [%v] from %s", msg.Command(),
+		p.conn.RemoteAddr())
+
+	// Use closures to log expensive operations so they are only run when
+	// the logging level requires it.
+	log.Tracef("%v", newLogClosure(func() string {
+		return "[PEER] " + spew.Sdump(msg)
+	}))
+	log.Tracef("%v", newLogClosure(func() string {
+		return "[PEER] " + spew.Sdump(buf)
+	}))
+
+	return
+}
+
+// writeMessage sends a bitcoin Message to the peer with logging.
+func (p *peer) writeMessage(msg btcwire.Message) error {
+	log.Debugf("[PEER] Sending command [%v] to %s", msg.Command(),
+		p.conn.RemoteAddr())
+
+	// Use closures to log expensive operations so they are only run when the
+	// logging level requires it.
+	log.Tracef("%v", newLogClosure(func() string {
+		return "[PEER] msg" + spew.Sdump(msg)
+	}))
+	log.Tracef("%v", newLogClosure(func() string {
+		var buf bytes.Buffer
+		err := btcwire.WriteMessage(&buf, msg, p.protocolVersion, p.btcnet)
+		if err != nil {
+			return err.Error()
+		}
+		return "[PEER] " + spew.Sdump(buf.Bytes())
+	}))
+
+	// Write the message to the peer.
+	err := btcwire.WriteMessage(p.conn, msg, p.protocolVersion, p.btcnet)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// isAllowedByRegression returns whether or not the passed error is allowed by
+// regression tests without disconnecting the peer.  In particular, regression
+// tests need to be allowed to send malformed messages without the peer being
+// disconnected.
+func (p *peer) isAllowedByRegression(err error) bool {
+	// Don't allow the error if it's not specifically a malformed message
+	// error.
+	if _, ok := err.(*btcwire.MessageError); !ok {
+		return false
+	}
+
+	// Don't allow the error if it's not coming from localhost or the
+	// hostname can't be determined for some reason.
+	host, _, err := net.SplitHostPort(p.conn.RemoteAddr().String())
+	if err != nil {
+		return false
+	}
+
+	if host != "127.0.0.1" && host != "localhost" {
+		return false
+	}
+
+	// Allowed if all checks passed.
+	return true
+}
+
+// inHandler handles all incoming messages for the peer.  It must be run as a
+// goroutine.
+func (p *peer) inHandler() {
+out:
+	for !p.disconnect {
+		rmsg, buf, err := p.readMessage()
+		if err != nil {
+			// In order to allow regression tests with malformed
+			// messages, don't disconnect the peer when we're in
+			// regression test mode and the error is one of the
+			// allowed errors.
+			if cfg.RegressionTest && p.isAllowedByRegression(err) {
+				log.Errorf("[PEER] %v", err)
+				continue
+			}
+
+			// Only log the error if we're not forcibly disconnecting.
+			if !p.disconnect {
+				log.Errorf("[PEER] %v", err)
+			}
+			break out
+		}
+
+		// Ensure version message comes first.
+		if _, ok := rmsg.(*btcwire.MsgVersion); !ok && !p.versionKnown {
+			log.Errorf("[PEER] A version message must precede all others")
+			break out
+		}
+
+		// Some messages are handled directly, while other messages
+		// are sent to a queue to be processed.  Directly handling
+		// getdata and getblocks messages makes it impossible for a peer
+		// to spam with requests.  However, it means that our getdata
+		// requests to it may not get prompt replies.
+		switch msg := rmsg.(type) {
+		case *btcwire.MsgVersion:
+			p.handleVersionMsg(msg)
+
+		case *btcwire.MsgVerAck:
+			// Do nothing.
+
+		case *btcwire.MsgGetAddr:
+			p.handleGetAddrMsg(msg)
+
+		case *btcwire.MsgAddr:
+			p.handleAddrMsg(msg)
+
+		case *btcwire.MsgPing:
+			p.handlePingMsg(msg)
+
+		case *btcwire.MsgPong:
+			// Don't do anything, but could try to work out network
+			// timing or similar.
+
+		case *btcwire.MsgAlert:
+			p.server.BroadcastMessage(msg, p)
+
+		case *btcwire.MsgBlock:
+			block := btcutil.NewBlockFromBlockAndBytes(msg, buf)
+			p.server.blockManager.QueueBlock(block)
+
+		case *btcwire.MsgInv:
+			p.server.blockManager.QueueInv(msg, p)
+
+		case *btcwire.MsgGetData:
+			p.handleGetDataMsg(msg)
+
+		case *btcwire.MsgGetBlocks:
+			p.handleGetBlocksMsg(msg)
+
+		case *btcwire.MsgGetHeaders:
+			p.handleGetHeadersMsg(msg)
+
+		default:
+			log.Debugf("[PEER] Received unhandled message of type %v: Fix Me",
+				rmsg.Command())
+		}
+	}
+
+	// Ensure connection is closed and notify server that the peer is done.
+	p.disconnect = true
+	p.conn.Close()
+	p.server.donePeers <- p
+	p.quit <- true
+
+	p.wg.Done()
+	log.Tracef("[PEER] Peer input handler done for %s", p.conn.RemoteAddr())
+}
+
+// outHandler handles all outgoing messages for the peer.  It must be run as a
+// goroutine.  It uses a buffered channel to serialize output messages while
+// allowing the sender to continue running asynchronously.
+func (p *peer) outHandler() {
+out:
+	for {
+		select {
+		case msg := <-p.outputQueue:
+			// Don't send anything if we're disconnected.
+			if p.disconnect {
+				continue
+			}
+			err := p.writeMessage(msg)
+			if err != nil {
+				p.disconnect = true
+				log.Errorf("[PEER] %v", err)
+			}
+
+		case <-p.quit:
+			break out
+		}
+	}
+	p.wg.Done()
+	log.Tracef("[PEER] Peer output handler done for %s", p.conn.RemoteAddr())
+}
+
+// QueueMessage adds the passed bitcoin message to the peer send queue.  It
+// uses a buffered channel to communicate with the output handler goroutine so
+// it is automatically rate limited and safe for concurrent access.
+func (p *peer) QueueMessage(msg btcwire.Message) {
+	p.outputQueue <- msg
+}
+
+// Start begins processing input and output messages.  It also sends the initial
+// version message for outbound connections to start the negotiation process.
+func (p *peer) Start() error {
+	// Already started?
+	if p.started {
+		return nil
+	}
+
+	log.Tracef("[PEER] Starting peer %s", p.conn.RemoteAddr())
+
+	// Send an initial version message if this is an outbound connection.
+	if !p.inbound {
+		err := p.pushVersionMsg()
+		if err != nil {
+			log.Errorf("[PEER] %v", err)
+			p.conn.Close()
+			return err
+		}
+	}
+
+	// Start processing input and output.
+	go p.inHandler()
+	go p.outHandler()
+	p.wg.Add(2)
+	p.started = true
+
+	// If server is shutting down, don't even start watchdog
+	if p.server.shutdown {
+		log.Debug("[PEER] server is shutting down")
+		return nil
+	}
+
+	return nil
+}
+
+// Shutdown gracefully shuts down the peer by signalling the async input and
+// output handler and waiting for them to finish.
+func (p *peer) Shutdown() {
+	log.Tracef("[PEER] Shutdown peer %s", p.conn.RemoteAddr())
+	p.disconnect = true
+	p.conn.Close()
+	p.wg.Wait()
+}
+
+// newPeer returns a new bitcoin peer for the provided server and connection.
+// Use start to begin processing incoming and outgoing messages.
+func newPeer(s *server, conn net.Conn, inbound bool, persistent bool) *peer {
+	p := peer{
+		server:          s,
+		protocolVersion: btcwire.ProtocolVersion,
+		btcnet:          s.btcnet,
+		services:        btcwire.SFNodeNetwork,
+		conn:            conn,
+		timeConnected:   time.Now(),
+		inbound:         inbound,
+		persistent:      persistent,
+		knownAddresses:  make(map[string]bool),
+		outputQueue:     make(chan btcwire.Message, outputBufferSize),
+		quit:            make(chan bool),
+	}
+	return &p
+}
+
+type logClosure func() string
+
+func (c logClosure) String() string {
+	return c()
+}
+
+func newLogClosure(c func() string) logClosure {
+	return logClosure(c)
+}

--- a/btcd/server.go
+++ b/btcd/server.go
@@ -1,0 +1,433 @@
+// Copyright (c) 2013 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"container/list"
+	"github.com/conformal/btcdb"
+	"github.com/conformal/btcwire"
+	"net"
+	"sync"
+	"time"
+)
+
+// supportedServices describes which services are supported by the server.
+const supportedServices = btcwire.SFNodeNetwork
+
+// connectionRetryInterval is the amount of time to wait in between retries
+// when connecting to persistent peers.
+const connectionRetryInterval = time.Second * 10
+
+// directionString is a helper function that returns a string that represents
+// the direction of a connection (inbound or outbound).
+func directionString(inbound bool) string {
+	if inbound {
+		return "inbound"
+	}
+	return "outbound"
+}
+
+// broadcastMsg provides the ability to house a bitcoin message to be broadcast
+// to all connected peers except specified excluded peers.
+type broadcastMsg struct {
+	message      btcwire.Message
+	excludePeers []*peer
+}
+
+// server provides a bitcoin server for handling communications to and from
+// bitcoin peers.
+type server struct {
+	nonce         uint64
+	listener      net.Listener
+	btcnet        btcwire.BitcoinNet
+	started       bool
+	shutdown      bool
+	shutdownSched bool
+	addrManager   *AddrManager
+	rpcServer     *rpcServer
+	blockManager  *blockManager
+	newPeers      chan *peer
+	donePeers     chan *peer
+	banPeers      chan *peer
+	broadcast     chan broadcastMsg
+	wg            sync.WaitGroup
+	quit          chan bool
+	db            btcdb.Db
+}
+
+// handleAddPeerMsg deals with adding new peers.  It is invoked from the
+// peerHandler goroutine.
+func (s *server) handleAddPeerMsg(peers *list.List, banned map[string]time.Time, p *peer) {
+
+	// Ignore new peers if we're shutting down.
+	direction := directionString(p.inbound)
+	if s.shutdown {
+		log.Infof("[SRVR] New peer %s (%s) ignored - server is "+
+			"shutting down", p.conn.RemoteAddr(), direction)
+		p.Shutdown()
+		return
+	}
+
+	// Disconnect banned peers.
+	host, _, err := net.SplitHostPort(p.conn.RemoteAddr().String())
+	if err != nil {
+		log.Errorf("[SRVR] %v", err)
+		p.Shutdown()
+		return
+	}
+	if banEnd, ok := banned[host]; ok {
+		if time.Now().Before(banEnd) {
+			log.Debugf("[SRVR] Peer %s is banned for another %v - "+
+				"disconnecting", host, banEnd.Sub(time.Now()))
+			p.Shutdown()
+			return
+		}
+
+		log.Infof("[SRVR] Peer %s is no longer banned", host)
+		delete(banned, host)
+	}
+
+	// TODO: Check for max peers from a single IP.
+
+	// Limit max number of total peers.
+	if peers.Len() >= cfg.MaxPeers {
+		log.Infof("[SRVR] Max peers reached [%d] - disconnecting "+
+			"peer %s (%s)", cfg.MaxPeers, p.conn.RemoteAddr(),
+			direction)
+		p.Shutdown()
+		return
+	}
+
+	// Add the new peer and start it.
+	log.Infof("[SRVR] New peer %s (%s)", p.conn.RemoteAddr(), direction)
+	peers.PushBack(p)
+	p.Start()
+}
+
+// handleDonePeerMsg deals with peers that have signalled they are done.  It is
+// invoked from the peerHandler goroutine.
+func (s *server) handleDonePeerMsg(peers *list.List, p *peer) {
+	direction := directionString(p.inbound)
+	for e := peers.Front(); e != nil; e = e.Next() {
+		if e.Value == p {
+			peers.Remove(e)
+			log.Infof("[SRVR] Removed peer %s (%s)",
+				p.conn.RemoteAddr(), direction)
+
+			// Issue an asynchronous reconnect if the peer was a
+			// persistent outbound connection.
+			if !p.inbound && p.persistent {
+				addr := p.conn.RemoteAddr().String()
+				s.ConnectPeerAsync(addr, true)
+			}
+			return
+		}
+	}
+}
+
+// handleBanPeerMsg deals with banning peers.  It is invoked from the
+// peerHandler goroutine.
+func (s *server) handleBanPeerMsg(banned map[string]time.Time, p *peer) {
+	host, _, err := net.SplitHostPort(p.conn.RemoteAddr().String())
+	if err != nil {
+		log.Errorf("[SRVR] %v", err)
+		return
+	}
+	direction := directionString(p.inbound)
+	log.Infof("[SRVR] Banned peer %s (%s) for %v", host, direction,
+		cfg.BanDuration)
+	banned[host] = time.Now().Add(cfg.BanDuration)
+
+}
+
+// handleBroadcastMsg deals with broadcasting messages to peers.  It is invoked
+// from the peerHandler goroutine.
+func (s *server) handleBroadcastMsg(peers *list.List, bmsg *broadcastMsg) {
+	for e := peers.Front(); e != nil; e = e.Next() {
+		excluded := false
+		for _, p := range bmsg.excludePeers {
+			if e.Value == p {
+				excluded = true
+			}
+		}
+		if !excluded {
+			p := e.Value.(*peer)
+			p.QueueMessage(bmsg.message)
+		}
+	}
+
+}
+
+// listenHandler is the main listener which accepts incoming connections for the
+// server.  It must be run as a goroutine.
+func (s *server) listenHandler() {
+	log.Infof("[SRVR] Server listening on %s", s.listener.Addr())
+	for !s.shutdown {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			// Only log the error if we're not forcibly shutting down.
+			if !s.shutdown {
+				log.Errorf("[SRVR] %v", err)
+			}
+			continue
+		}
+		s.AddPeer(newPeer(s, conn, true, false))
+	}
+	s.wg.Done()
+	log.Tracef("[SRVR] Listener handler done for %s", s.listener.Addr())
+}
+
+// peerHandler is used to handle peer operations such as adding and removing
+// peers to and from the server, banning peers, and broadcasting messages to
+// peers.  It must be run a a goroutine.
+func (s *server) peerHandler() {
+	log.Tracef("[SRVR] Starting peer handler for %s", s.listener.Addr())
+	peers := list.New()
+	bannedPeers := make(map[string]time.Time)
+
+	// Live while we're not shutting down or there are still connected peers.
+	for !s.shutdown || peers.Len() != 0 {
+		select {
+
+		// New peers connected to the server.
+		case p := <-s.newPeers:
+			s.handleAddPeerMsg(peers, bannedPeers, p)
+
+		// Disconnected peers.
+		case p := <-s.donePeers:
+			s.handleDonePeerMsg(peers, p)
+
+		// Peer to ban.
+		case p := <-s.banPeers:
+			s.handleBanPeerMsg(bannedPeers, p)
+
+		// Message to broadcast to all connected peers except those
+		// which are excluded by the message.
+		case bmsg := <-s.broadcast:
+			s.handleBroadcastMsg(peers, &bmsg)
+
+		// Shutdown the peer handler.
+		case <-s.quit:
+			// Shutdown peers.
+			for e := peers.Front(); e != nil; e = e.Next() {
+				p := e.Value.(*peer)
+				p.Shutdown()
+			}
+		}
+	}
+	s.wg.Done()
+	log.Tracef("[SRVR] Peer handler done on %s", s.listener.Addr())
+}
+
+// AddPeer adds a new peer that has already been connected to the server.
+func (s *server) AddPeer(p *peer) {
+	s.newPeers <- p
+}
+
+// BanPeer bans a peer that has already been connected to the server by ip.
+func (s *server) BanPeer(p *peer) {
+	s.banPeers <- p
+}
+
+// BroadcastMessage sends msg to all peers currently connected to the server
+// except those in the passed peers to exclude.
+func (s *server) BroadcastMessage(msg btcwire.Message, exclPeers ...*peer) {
+	// XXX: Need to determine if this is an alert that has already been
+	// broadcast and refrain from broadcasting again.
+	bmsg := broadcastMsg{message: msg, excludePeers: exclPeers}
+	s.broadcast <- bmsg
+}
+
+// ConnectPeerAsync attempts to asynchronously connect to addr.  If successful,
+// a new peer is created and added to the server's peer list.
+func (s *server) ConnectPeerAsync(addr string, persistent bool) {
+	// Don't try to connect to a peer if the server is shutting down.
+	if s.shutdown {
+		return
+	}
+
+	go func() {
+		// Attempt to connect to the peer.  If the connection fails and
+		// this is a persistent connection, retry after the retry
+		// interval.
+		for !s.shutdown {
+			log.Debugf("[SRVR] Attempting to connect to %s", addr)
+			conn, err := net.Dial("tcp", addr)
+			if err != nil {
+				log.Errorf("[SRVR] %v", err)
+				if !persistent {
+					return
+				}
+				log.Infof("[SRVR] Retrying connection to %s "+
+					"in %s", addr, connectionRetryInterval)
+				time.Sleep(connectionRetryInterval)
+				continue
+			}
+
+			// Connection was successful so log it and create a new
+			// peer.
+			log.Infof("[SRVR] Connected to %s", conn.RemoteAddr())
+			s.AddPeer(newPeer(s, conn, false, persistent))
+			return
+		}
+	}()
+}
+
+// Start begins accepting connections from peers.
+func (s *server) Start() {
+	// Already started?
+	if s.started {
+		return
+	}
+
+	log.Trace("[SRVR] Starting server")
+	go s.listenHandler()
+	go s.peerHandler()
+	s.wg.Add(2)
+	s.addrManager.Start()
+	s.blockManager.Start()
+	if !cfg.DisableRpc {
+		s.rpcServer.Start()
+	}
+
+	s.started = true
+}
+
+// Stop gracefully shuts down the server by stopping and disconnecting all
+// peers and the main listener.
+func (s *server) Stop() error {
+	if s.shutdown {
+		log.Infof("[SRVR] Server is already in the process of shutting down")
+		return nil
+	}
+
+	log.Warnf("[SRVR] Server shutting down")
+	s.shutdown = true
+	s.quit <- true
+	if !cfg.DisableRpc {
+		s.rpcServer.Stop()
+	}
+	s.addrManager.Stop()
+	s.blockManager.Stop()
+	err := s.listener.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// WaitForShutdown blocks until the main listener and peer handlers are stopped.
+func (s *server) WaitForShutdown() {
+	s.wg.Wait()
+	log.Infof("[SRVR] Server shutdown complete")
+}
+
+// ScheduleShutdown schedules a server shutdown after the specified duration.
+// It also dynamically adjusts how often to warn the server is going down based
+// on remaining duration.
+func (s *server) ScheduleShutdown(duration time.Duration) {
+	// Don't schedule shutdown more than once.
+	if s.shutdownSched {
+		return
+	}
+	log.Warnf("[SRVR] Server shutdown in %v", duration)
+	go func() {
+		remaining := duration
+		tickDuration := dynamicTickDuration(remaining)
+		done := time.After(remaining)
+		ticker := time.NewTicker(tickDuration)
+	out:
+		for {
+			select {
+			case <-done:
+				ticker.Stop()
+				s.Stop()
+				break out
+			case <-ticker.C:
+				remaining = remaining - tickDuration
+				if remaining < time.Second {
+					continue
+				}
+
+				// Change tick duration dynamically based on remaining time.
+				newDuration := dynamicTickDuration(remaining)
+				if tickDuration != newDuration {
+					tickDuration = newDuration
+					ticker.Stop()
+					ticker = time.NewTicker(tickDuration)
+				}
+				log.Warnf("[SRVR] Server shutdown in %v", remaining)
+			}
+		}
+	}()
+	s.shutdownSched = true
+}
+
+// newServer returns a new btcd server configured to listen on addr for the
+// bitcoin network type specified in btcnet.  Use start to begin accepting
+// connections from peers.
+func newServer(addr string, db btcdb.Db, btcnet btcwire.BitcoinNet) (*server, error) {
+	nonce, err := btcwire.RandomUint64()
+	if err != nil {
+		return nil, err
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	s := server{
+		nonce:       nonce,
+		listener:    listener,
+		btcnet:      btcnet,
+		addrManager: NewAddrManager(),
+		newPeers:    make(chan *peer, cfg.MaxPeers),
+		donePeers:   make(chan *peer, cfg.MaxPeers),
+		banPeers:    make(chan *peer, cfg.MaxPeers),
+		broadcast:   make(chan broadcastMsg, cfg.MaxPeers),
+		quit:        make(chan bool),
+		db:          db,
+	}
+	s.blockManager = newBlockManager(&s)
+
+	log.Infof("[BMGR] Generating initial block node index.  This may " +
+		"take a while...")
+	err = s.blockManager.blockChain.GenerateInitialIndex()
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("[BMGR] Block index generation complete")
+
+	if !cfg.DisableRpc {
+		s.rpcServer, err = newRpcServer(&s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &s, nil
+}
+
+// dynamicTickDuration is a convenience function used to dynamically choose a
+// tick duration based on remaining time.  It is primarily used during
+// server shutdown to make shutdown warnings more frequent as the shutdown time
+// approaches.
+func dynamicTickDuration(remaining time.Duration) time.Duration {
+	switch {
+	case remaining <= time.Second*5:
+		return time.Second
+	case remaining <= time.Second*15:
+		return time.Second * 5
+	case remaining <= time.Minute:
+		return time.Second * 15
+	case remaining <= time.Minute*5:
+		return time.Minute
+	case remaining <= time.Minute*15:
+		return time.Minute * 5
+	case remaining <= time.Hour:
+		return time.Minute * 15
+	}
+	return time.Hour
+}

--- a/cmd/kaspawallet/daemon/server/broadcast.go
+++ b/cmd/kaspawallet/daemon/server/broadcast.go
@@ -43,7 +43,15 @@ func (s *server) broadcast(transactions [][]byte, isDomain bool) ([]string, erro
 
 		txIDs[i], err = sendTransaction(s.rpcClient, tx)
 		if err != nil {
+			for _, input := range tx.Inputs {
+				s.tracker.untrackOutpointAsReserved(input.PreviousOutpoint)
+			}
 			return nil, err
+		}
+
+		for _, input := range tx.Inputs {
+			s.tracker.trackOutpointAsSent(input.PreviousOutpoint)
+			s.tracker.untrackOutpointAsReserved(input.PreviousOutpoint)
 		}
 	}
 

--- a/cmd/kaspawallet/daemon/server/broadcast.go
+++ b/cmd/kaspawallet/daemon/server/broadcast.go
@@ -46,7 +46,7 @@ func (s *server) broadcast(transactions [][]byte, isDomain bool) ([]string, erro
 			return nil, err
 		}
 
-		s.tracker.trackTransactionID(tx.ID)
+		s.tracker.trackTransaction(tx)
 
 		for _, input := range tx.Inputs {
 			s.tracker.trackOutpointAsSent(input.PreviousOutpoint.Clone())

--- a/cmd/kaspawallet/daemon/server/broadcast.go
+++ b/cmd/kaspawallet/daemon/server/broadcast.go
@@ -46,8 +46,10 @@ func (s *server) broadcast(transactions [][]byte, isDomain bool) ([]string, erro
 			return nil, err
 		}
 
+		s.tracker.trackTransactionID(tx.ID)
+
 		for _, input := range tx.Inputs {
-			s.tracker.trackOutpointAsSent(input.PreviousOutpoint)
+			s.tracker.trackOutpointAsSent(input.PreviousOutpoint.Clone())
 			s.tracker.untrackOutpointAsReserved(input.PreviousOutpoint)
 		}
 	}
@@ -60,5 +62,6 @@ func sendTransaction(client *rpcclient.RPCClient, tx *externalapi.DomainTransact
 	if err != nil {
 		return "", errors.Wrapf(err, "error submitting transaction")
 	}
+
 	return submitTransactionResponse.TransactionID, nil
 }

--- a/cmd/kaspawallet/daemon/server/broadcast.go
+++ b/cmd/kaspawallet/daemon/server/broadcast.go
@@ -47,11 +47,6 @@ func (s *server) broadcast(transactions [][]byte, isDomain bool) ([]string, erro
 		}
 
 		s.tracker.trackTransaction(tx)
-
-		for _, input := range tx.Inputs {
-			s.tracker.trackOutpointAsSent(input.PreviousOutpoint.Clone())
-			s.tracker.untrackOutpointAsReserved(input.PreviousOutpoint)
-		}
 	}
 
 	return txIDs, nil

--- a/cmd/kaspawallet/daemon/server/broadcast.go
+++ b/cmd/kaspawallet/daemon/server/broadcast.go
@@ -22,7 +22,8 @@ func (s *server) Broadcast(_ context.Context, request *pb.BroadcastRequest) (*pb
 }
 
 func (s *server) broadcast(transactions [][]byte, isDomain bool) ([]string, error) {
-
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	txIDs := make([]string, len(transactions))
 	var tx *externalapi.DomainTransaction
 	var err error
@@ -42,11 +43,12 @@ func (s *server) broadcast(transactions [][]byte, isDomain bool) ([]string, erro
 		}
 
 		txIDs[i], err = sendTransaction(s.rpcClient, tx)
+		s.tracker.trackTransaction(tx)
 		if err != nil {
 			return nil, err
 		}
 
-		s.tracker.trackTransaction(tx)
+		//s.tracker.trackTransaction(tx)
 	}
 
 	return txIDs, nil

--- a/cmd/kaspawallet/daemon/server/broadcast.go
+++ b/cmd/kaspawallet/daemon/server/broadcast.go
@@ -43,9 +43,6 @@ func (s *server) broadcast(transactions [][]byte, isDomain bool) ([]string, erro
 
 		txIDs[i], err = sendTransaction(s.rpcClient, tx)
 		if err != nil {
-			for _, input := range tx.Inputs {
-				s.tracker.untrackOutpointAsReserved(input.PreviousOutpoint)
-			}
 			return nil, err
 		}
 

--- a/cmd/kaspawallet/daemon/server/create_unsigned_transaction.go
+++ b/cmd/kaspawallet/daemon/server/create_unsigned_transaction.go
@@ -102,7 +102,7 @@ func (s *server) selectUTXOs(spendAmount uint64, feePerInput uint64, fromAddress
 			!isUTXOSpendable(utxo, dagInfo.VirtualDAAScore, s.params.BlockCoinbaseMaturity) {
 			continue
 		}
-		s.tracker.trackOutpointAsReserved(*utxo.Outpoint)
+		s.tracker.trackOutpointAsReserved(utxo.Outpoint)
 
 		selectedUTXOs = append(selectedUTXOs, &libkaspawallet.UTXO{
 			Outpoint:       utxo.Outpoint,

--- a/cmd/kaspawallet/daemon/server/create_unsigned_transaction.go
+++ b/cmd/kaspawallet/daemon/server/create_unsigned_transaction.go
@@ -32,10 +32,10 @@ func (s *server) createUnsignedTransactions(address string, amount uint64, fromA
 		return nil, errors.New("server is not synced")
 	}
 
-	err := s.refreshUTXOs()
-	if err != nil {
-		return nil, err
-	}
+	//err := s.refreshUTXOs()
+	//if err != nil {
+	//	return nil, err
+	//}
 
 	toAddress, err := util.DecodeAddress(address, s.params.Prefix)
 	if err != nil {

--- a/cmd/kaspawallet/daemon/server/create_unsigned_transaction.go
+++ b/cmd/kaspawallet/daemon/server/create_unsigned_transaction.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"golang.org/x/exp/slices"
 
 	"github.com/kaspanet/kaspad/cmd/kaspawallet/daemon/pb"
 	"github.com/kaspanet/kaspad/cmd/kaspawallet/libkaspawallet"

--- a/cmd/kaspawallet/daemon/server/server.go
+++ b/cmd/kaspawallet/daemon/server/server.go
@@ -28,13 +28,15 @@ type server struct {
 	rpcClient *rpcclient.RPCClient
 	params    *dagconfig.Params
 
-	lock                sync.RWMutex
-	utxosSortedByAmount []*walletUTXO
-	nextSyncStartIndex  uint32
-	keysFile            *keys.File
-	shutdown            chan struct{}
-	addressSet          walletAddressSet
-	txMassCalculator    *txmass.Calculator
+	lock                         sync.RWMutex
+	utxosSortedByAmount          []*walletUTXO
+	availableUtxosSortedByAmount []*walletUTXO
+	nextSyncStartIndex           uint32
+	keysFile                     *keys.File
+	shutdown                     chan struct{}
+	addressSet                   walletAddressSet
+	txMassCalculator             *txmass.Calculator
+	tracker                      *Tracker
 }
 
 // Start starts the kaspawalletd server
@@ -65,14 +67,16 @@ func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath stri
 	}
 
 	serverInstance := &server{
-		rpcClient:           rpcClient,
-		params:              params,
-		utxosSortedByAmount: []*walletUTXO{},
-		nextSyncStartIndex:  0,
-		keysFile:            keysFile,
-		shutdown:            make(chan struct{}),
-		addressSet:          make(walletAddressSet),
-		txMassCalculator:    txmass.NewCalculator(params.MassPerTxByte, params.MassPerScriptPubKeyByte, params.MassPerSigOp),
+		rpcClient:                    rpcClient,
+		params:                       params,
+		utxosSortedByAmount:          []*walletUTXO{},
+		availableUtxosSortedByAmount: []*walletUTXO{},
+		nextSyncStartIndex:           0,
+		keysFile:                     keysFile,
+		shutdown:                     make(chan struct{}),
+		addressSet:                   make(walletAddressSet),
+		txMassCalculator:             txmass.NewCalculator(params.MassPerTxByte, params.MassPerScriptPubKeyByte, params.MassPerSigOp),
+		tracker:                      NewTracker(),
 	}
 
 	spawn("serverInstance.sync", func() {

--- a/cmd/kaspawallet/daemon/server/split_transaction.go
+++ b/cmd/kaspawallet/daemon/server/split_transaction.go
@@ -254,13 +254,16 @@ func (s *server) moreUTXOsForMergeTransaction(alreadySelectedUTXOs []*libkaspawa
 		alreadySelectedUTXOsMap[*alreadySelectedUTXO.Outpoint] = struct{}{}
 	}
 
-	for _, utxo := range s.utxosSortedByAmount {
+	for _, utxo := range s.availableUtxosSortedByAmount {
 		if _, ok := alreadySelectedUTXOsMap[*utxo.Outpoint]; ok {
 			continue
 		}
 		if !isUTXOSpendable(utxo, dagInfo.VirtualDAAScore, s.params.BlockCoinbaseMaturity) {
 			continue
 		}
+
+		s.tracker.trackOutpointAsReserved(*utxo.Outpoint)
+
 		additionalUTXOs = append(additionalUTXOs, &libkaspawallet.UTXO{
 			Outpoint:       utxo.Outpoint,
 			UTXOEntry:      utxo.UTXOEntry,

--- a/cmd/kaspawallet/daemon/server/split_transaction.go
+++ b/cmd/kaspawallet/daemon/server/split_transaction.go
@@ -262,7 +262,7 @@ func (s *server) moreUTXOsForMergeTransaction(alreadySelectedUTXOs []*libkaspawa
 			continue
 		}
 
-		s.tracker.trackOutpointAsReserved(*utxo.Outpoint)
+		s.tracker.trackOutpointAsReserved(utxo.Outpoint)
 
 		additionalUTXOs = append(additionalUTXOs, &libkaspawallet.UTXO{
 			Outpoint:       utxo.Outpoint,

--- a/cmd/kaspawallet/daemon/server/sync.go
+++ b/cmd/kaspawallet/daemon/server/sync.go
@@ -29,14 +29,23 @@ func (s *server) sync() error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	for i := range ticker.C {
-		fmt.Println(i)
-		err := s.collectRecentAddresses()
+	err := s.collectRecentAddresses()
+	if err != nil {
+		return err
+	}
+
+	err = s.refreshExistingUTXOsWithLock()
+	if err != nil {
+		return err
+	}
+
+	for range ticker.C {
+		err = s.collectFarAddresses()
 		if err != nil {
 			return err
 		}
 
-		err = s.collectFarAddresses()
+		err = s.collectRecentAddresses()
 		if err != nil {
 			return err
 		}

--- a/cmd/kaspawallet/daemon/server/sync.go
+++ b/cmd/kaspawallet/daemon/server/sync.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/kaspanet/kaspad/cmd/kaspawallet/libkaspawallet"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
-	"github.com/kaspanet/kaspad/domain/consensus/utils/txscript"
 
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/pkg/errors"
@@ -39,7 +38,8 @@ func (s *server) sync() error {
 		return err
 	}
 
-	for range ticker.C {
+	for i := range ticker.C {
+		fmt.Println(i)
 		err = s.collectFarAddresses()
 		if err != nil {
 			return err
@@ -247,7 +247,7 @@ func (s *server) updateUTXOSet(entries []*appmessage.UTXOsByAddressesEntry) erro
 			}
 		}
 	}
-
+		
 	s.tracker.untrackTransactionDifference(mempoolTransactions)   //clean up transaction tracker
 	s.tracker.mempoolOutpoints = mempoolWalletAddressesOutpoints //clean up sent outpoint tracker
 

--- a/cmd/kaspawallet/daemon/server/sync.go
+++ b/cmd/kaspawallet/daemon/server/sync.go
@@ -42,7 +42,6 @@ func (s *server) sync() error {
 		}
 
 		err = s.refreshExistingUTXOsWithLock()
-
 		if err != nil {
 			return err
 		}
@@ -107,16 +106,24 @@ func (s *server) maxUsedIndex() uint32 {
 
 // collectRecentAddresses collects addresses from used addresses until
 // the address with the index of the last used address + 1000.
-// collectRecentAddresses scans addresses in batches of numIndexesToQuery,
+// collectRecentAddresses scans addresses in batches of 1000,
 // and releases the lock between scans.
 func (s *server) collectRecentAddresses() error {
-	maxUsedIndex := s.maxUsedIndex()
-	for i := uint32(0); i < maxUsedIndex+1000; i += numIndexesToQuery {
-		err := s.collectAddressesWithLock(i, i+numIndexesToQuery)
+	index := uint32(0)
+	maxUsedIndex := uint32(0)
+	for ; index < maxUsedIndex+1000; index += 1000 {
+		err := s.collectAddressesWithLock(index, index+1000)
 		if err != nil {
 			return err
 		}
+		maxUsedIndex = s.maxUsedIndex()
 	}
+
+	s.lock.Lock()
+	if index > s.nextSyncStartIndex {
+		s.nextSyncStartIndex = index
+	}
+	s.lock.Unlock()
 
 	return nil
 }

--- a/cmd/kaspawallet/daemon/server/sync.go
+++ b/cmd/kaspawallet/daemon/server/sync.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -193,7 +194,7 @@ func (s *server) updateUTXOSet(entries []*appmessage.UTXOsByAddressesEntry) erro
 	utxos := make([]*walletUTXO, len(entries))
 
 	s.tracker.untrackExpiredOutpointsAsResrved() //untrack all stale reserved outpoints, before comparing in loop
-	availableUtxos := make([]*walletUTXO, len(entries))
+	availableUtxos := make([]*walletUTXO, 0)
 
 	for i, entry := range entries {
 		outpoint, err := appmessage.RPCOutpointToDomainOutpoint(entry.Outpoint)
@@ -229,11 +230,11 @@ func (s *server) updateUTXOSet(entries []*appmessage.UTXOsByAddressesEntry) erro
 
 	s.utxosSortedByAmount = utxos
 
-	sort.Slice(availableUtxos, func(i, j int) bool { return utxos[i].UTXOEntry.Amount() > utxos[j].UTXOEntry.Amount() })
+	sort.Slice(availableUtxos, func(i, j int) bool { return availableUtxos[i].UTXOEntry.Amount() > availableUtxos[j].UTXOEntry.Amount() })
 
 	s.availableUtxosSortedByAmount = availableUtxos
 
-	s.tracker.untrackOutpointDifferenceViaWalletUTXOs(utxos) //keep this call after sorting! should speed things up.
+	s.tracker.untrackOutpointDifferenceViaWalletUTXOs(utxos) //clean up tracker
 
 	return nil
 }

--- a/cmd/kaspawallet/daemon/server/sync.go
+++ b/cmd/kaspawallet/daemon/server/sync.go
@@ -219,7 +219,8 @@ func (s *server) updateUTXOSet(entries []*appmessage.UTXOsByAddressesEntry) erro
 		)
 		if s.tracker.isTransactionTracked(transaction) {
 			for _, input := range transaction.Inputs {
-				_, address, err := txscript.ExtractScriptPubKeyAddress(input.UTXOEntry.ScriptPublicKey(), s.params)
+				scriptPubKey := input.UTXOEntry.ScriptPublicKey()
+				_, address, err := txscript.ExtractScriptPubKeyAddress(scriptPubKey, s.params)
 				if err != nil {
 					return err
 				}

--- a/cmd/kaspawallet/daemon/server/sync.go
+++ b/cmd/kaspawallet/daemon/server/sync.go
@@ -247,8 +247,8 @@ func (s *server) updateUTXOSet(entries []*appmessage.UTXOsByAddressesEntry) erro
 			}
 		}
 	}
-		
-	s.tracker.untrackTransactionDifference(mempoolTransactions)   //clean up transaction tracker
+
+	s.tracker.untrackTransactionDifference(mempoolTransactions)  //clean up transaction tracker
 	s.tracker.mempoolOutpoints = mempoolWalletAddressesOutpoints //clean up sent outpoint tracker
 
 	for i, entry := range entries {
@@ -296,7 +296,6 @@ func (s *server) updateUTXOSet(entries []*appmessage.UTXOsByAddressesEntry) erro
 	fmt.Println("utxos mempool", len(s.tracker.mempoolOutpoints))
 	fmt.Println("utxos reserved", len(s.tracker.reservedOutpoints))
 	fmt.Println("transactions in mempool", len(s.tracker.sentTransactions))
-
 
 	s.tracker.untrackOutpointDifferenceViaWalletUTXOs(utxos) //clean up reserved tracker
 

--- a/cmd/kaspawallet/daemon/server/tracker.go
+++ b/cmd/kaspawallet/daemon/server/tracker.go
@@ -78,7 +78,6 @@ func (tr *Tracker) untrackExpiredOutpointsAsReserved() {
 	}
 }
 
-
 func (tr *Tracker) untrackSentTransactionID(transactionID string) {
 	delete(tr.sentTransactions, transactionID)
 }
@@ -97,4 +96,12 @@ func (tr *Tracker) trackTransaction(transaction *externalapi.DomainTransaction) 
 
 func (tr *Tracker) untrackOutpointAsReserved(outpoint externalapi.DomainOutpoint) {
 	delete(tr.reservedOutpoints, outpoint)
+}
+
+func (tr *Tracker) countOutpointsInmempool() int {
+	numOfOutpoints := 0
+	for _, value := range tr.sentTransactions {
+		numOfOutpoints = numOfOutpoints + len(value)
+	}
+	return numOfOutpoints
 }

--- a/cmd/kaspawallet/daemon/server/tracker.go
+++ b/cmd/kaspawallet/daemon/server/tracker.go
@@ -4,16 +4,17 @@ import (
 	"time"
 
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"github.com/kaspanet/kaspad/domain/consensus/utils/consensushashing"
 )
 
 type reservedOutpoints map[externalapi.DomainOutpoint]int64
-type sentOutpoints map[externalapi.DomainOutpoint]bool
+type mempoolOutpoints map[externalapi.DomainOutpoint]bool
 type sentTransactions map[externalapi.DomainTransactionID]bool
 
 //Tracker tracks wallet server utxos via outpoints.
 type Tracker struct {
 	reservedOutpoints        reservedOutpoints
-	sentOutpoints            sentOutpoints
+	mempoolOutpoints         mempoolOutpoints
 	sentTransactions         sentTransactions
 	expiryDurationInSecounds int64
 }
@@ -22,27 +23,36 @@ type Tracker struct {
 func NewTracker() *Tracker {
 	return &Tracker{
 		reservedOutpoints:        make(reservedOutpoints),
-		sentOutpoints:            make(sentOutpoints),
+		mempoolOutpoints:         make(mempoolOutpoints),
 		sentTransactions:         make(sentTransactions),
 		expiryDurationInSecounds: 1, // 1 corrosponds to a sync ticker interval, as well as current average BPS
 	}
 }
 
 func (tr *Tracker) isOutpointAvailable(outpoint *externalapi.DomainOutpoint) bool {
-	var found bool
-
-	if _, found = tr.reservedOutpoints[*outpoint]; found {
-		return false
-	}
-
-	if _, found = tr.sentOutpoints[*outpoint]; found {
+	if tr.isOutpointReserved(outpoint) || tr.isOutpointInMempool(outpoint) {
 		return false
 	}
 
 	return true
 }
 
-func (tr *Tracker) untrackExpiredOutpointsAsResrved() {
+func (tr *Tracker) isTransactionTracked(transaction *externalapi.DomainTransaction) bool {
+	_, found := tr.sentTransactions[*consensushashing.TransactionID(transaction)]
+	return found
+}
+
+func (tr *Tracker) isOutpointInMempool(outpoint *externalapi.DomainOutpoint) bool {
+	_, found := tr.mempoolOutpoints[*outpoint]
+	return found
+}
+
+func (tr *Tracker) isOutpointReserved(outpoint *externalapi.DomainOutpoint) bool {
+	_, found := tr.reservedOutpoints[*outpoint]
+	return found
+}
+
+func (tr *Tracker) untrackExpiredOutpointsAsReserved() {
 	currentTimestamp := time.Now().Unix()
 	for outpoint, reserveTimestamp := range tr.reservedOutpoints {
 		if currentTimestamp-reserveTimestamp >= tr.expiryDurationInSecounds {
@@ -52,7 +62,7 @@ func (tr *Tracker) untrackExpiredOutpointsAsResrved() {
 	}
 	for outpoint, sentTimestamp := range tr.reservedOutpoints {
 		if currentTimestamp-sentTimestamp >= tr.expiryDurationInSecounds {
-			delete(tr.sentOutpoints, outpoint)
+			delete(tr.mempoolOutpoints, outpoint)
 		}
 	}
 }
@@ -61,26 +71,26 @@ func (tr *Tracker) untrackOutpointDifferenceViaWalletUTXOs(utxos []*walletUTXO) 
 
 	validOutpoints := make(map[externalapi.DomainOutpoint]bool, len(utxos))
 	for _, utxo := range utxos {
-		validOutpoints[*utxo.Outpoint.Clone()] = true
+		validOutpoints[*utxo.Outpoint] = true
 	}
 	for reservedOutpoint := range tr.reservedOutpoints {
 		if _, found := validOutpoints[reservedOutpoint]; !found {
 			delete(tr.reservedOutpoints, reservedOutpoint)
 		}
 	}
-	for sentOutpoint := range tr.sentOutpoints {
+	for sentOutpoint := range tr.mempoolOutpoints {
 		if _, found := validOutpoints[sentOutpoint]; !found {
-			delete(tr.sentOutpoints, sentOutpoint)
+			delete(tr.mempoolOutpoints, sentOutpoint)
 		}
 	}
 }
 
-func (tr *Tracker) untrackTransactionIDDifference(transactionIDs []*externalapi.DomainTransactionID) {
+func (tr *Tracker) untrackTransactionDifference(transactions []*externalapi.DomainTransaction) {
 
-	validTransactionIDs := make(sentTransactions, len(transactionIDs))
+	validTransactionIDs := make(sentTransactions, len(transactions))
 
-	for _, transactionID := range transactionIDs {
-		validTransactionIDs[*transactionID.Clone()] = true
+	for _, transaction := range transactions {
+		validTransactionIDs[*consensushashing.TransactionID(transaction)] = true
 	}
 	for sentTransaction := range tr.sentTransactions {
 		if _, found := validTransactionIDs[sentTransaction]; !found {
@@ -90,15 +100,15 @@ func (tr *Tracker) untrackTransactionIDDifference(transactionIDs []*externalapi.
 }
 
 func (tr *Tracker) trackOutpointAsReserved(outpoint *externalapi.DomainOutpoint) {
-	tr.reservedOutpoints[*outpoint.Clone()] = time.Now().Unix()
+	tr.reservedOutpoints[*outpoint] = time.Now().Unix()
 }
 
 func (tr *Tracker) trackOutpointAsSent(outpoint *externalapi.DomainOutpoint) {
-	tr.sentOutpoints[*outpoint.Clone()] = true
+	tr.mempoolOutpoints[*outpoint] = true
 }
 
-func (tr *Tracker) trackTransactionID(transactionID *externalapi.DomainTransactionID) {
-	tr.sentTransactions[*transactionID.Clone()] = true
+func (tr *Tracker) trackTransaction(transaction *externalapi.DomainTransaction) {
+	tr.sentTransactions[*consensushashing.TransactionID(transaction)] = true
 }
 
 func (tr *Tracker) untrackOutpointAsReserved(outpoint externalapi.DomainOutpoint) {

--- a/cmd/kaspawallet/daemon/server/tracker.go
+++ b/cmd/kaspawallet/daemon/server/tracker.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
+	"time"
+)
+
+type reservedOutpoints map[externalapi.DomainOutpoint]int64
+type sentOutpoints map[externalapi.DomainOutpoint]int64
+
+//Tracker tracks wallet server utxos via outpoints.
+type Tracker struct {
+	reservedOutpoints        reservedOutpoints
+	sentOutpoints            sentOutpoints
+	expiryDurationInSecounds int64
+}
+
+//NewTracker intializes and returns a new Tracker
+func NewTracker() *Tracker {
+	return &Tracker{
+		reservedOutpoints:        make(reservedOutpoints),
+		sentOutpoints:            make(sentOutpoints),
+		expiryDurationInSecounds: 3, // 3 is somewhat aribitary
+	}
+}
+
+func (tr *Tracker) isOutpointAvailable(outpoint *externalapi.DomainOutpoint) bool {
+	var found bool
+
+	_, found = tr.reservedOutpoints[*outpoint]
+	if found {
+		return false
+	}
+	_, found = tr.sentOutpoints[*outpoint]
+	if found {
+		return false
+	}
+
+	return true
+}
+
+func (tr *Tracker) untrackExpiredOutpointsAsResrved() {
+	currentTimestamp := time.Now().Unix()
+	for outpoint, reserveTimestamp := range tr.reservedOutpoints {
+		if currentTimestamp-reserveTimestamp >= tr.expiryDurationInSecounds {
+			delete(tr.reservedOutpoints, outpoint)
+		}
+
+	}
+}
+
+func (tr *Tracker) untrackOutpointDifferenceViaWalletUTXOs(utxos []*walletUTXO) {
+
+	for trackedOutpoint := range tr.sentOutpoints {
+		for _, utxo := range utxos {
+			outpoint := externalapi.DomainOutpoint{
+				TransactionID: utxo.Outpoint.TransactionID,
+				Index:         utxo.Outpoint.Index,
+			}
+			if trackedOutpoint == outpoint {
+				break
+			}
+			delete(tr.sentOutpoints, trackedOutpoint)
+
+		}
+	}
+
+	for trackedOutpoint := range tr.reservedOutpoints {
+		for _, utxo := range utxos {
+			outpoint := externalapi.DomainOutpoint{
+				TransactionID: utxo.Outpoint.TransactionID,
+				Index:         utxo.Outpoint.Index,
+			}
+			if trackedOutpoint == outpoint {
+				break
+			}
+			delete(tr.reservedOutpoints, trackedOutpoint)
+		}
+	}
+
+}
+
+func (tr *Tracker) trackOutpointAsReserved(outpoint externalapi.DomainOutpoint) {
+	tr.reservedOutpoints[outpoint] = time.Now().Unix()
+}
+
+func (tr *Tracker) trackOutpointAsSent(outpoint externalapi.DomainOutpoint) {
+	tr.sentOutpoints[outpoint] = time.Now().Unix()
+}
+
+func (tr *Tracker) untrackOutpointAsReserved(outpoint externalapi.DomainOutpoint) {
+	delete(tr.reservedOutpoints, outpoint)
+}


### PR DESCRIPTION
stop wallet from reusing spent utxos, when spamming transactions.

fixes #1984

1) adds a transaction and utxo outpoint tracking mechanisim

This is not ready for reveiw! and work in progress! - also some fmts for debugging are still in the code.

Ideally i see further optimisations by letting the wallet server use notification messages, and get messages only at start-up, but this is perhaps for another PR. 

btw I merged the fast sync, because my wallet wouldn't work otherwise. 