### PR TITLE
RPC: filter utxos not consensusState - perhaps fixes the orphan problem. 

### DIFF
--- a/app/rpc/rpccontext/context.go
+++ b/app/rpc/rpccontext/context.go
@@ -44,7 +44,7 @@ func NewContext(cfg *config.Config,
 		UTXOIndex:         utxoIndex,
 		ShutDownChan:      shutDownChan,
 	}
-	context.NotificationManager = NewNotificationManager()
+	context.NotificationManager = NewNotificationManager(context)
 
 	return context
 }

--- a/app/rpc/rpccontext/utxos_by_addresses.go
+++ b/app/rpc/rpccontext/utxos_by_addresses.go
@@ -2,6 +2,8 @@ package rpccontext
 
 import (
 	"encoding/hex"
+
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/txscript"
 	"github.com/kaspanet/kaspad/util"
 	"github.com/pkg/errors"
@@ -10,22 +12,24 @@ import (
 	"github.com/kaspanet/kaspad/domain/utxoindex"
 )
 
-// ConvertUTXOOutpointEntryPairsToUTXOsByAddressesEntries converts
-// UTXOOutpointEntryPairs to a slice of UTXOsByAddressesEntry
-func ConvertUTXOOutpointEntryPairsToUTXOsByAddressesEntries(address string, pairs utxoindex.UTXOOutpointEntryPairs) []*appmessage.UTXOsByAddressesEntry {
+// ConvertDomainOutpointEntryPairsToUTXOsByAddressesEntries converts
+// *externalapi.OutpointAndUTXOEntryPairs to a slice of UTXOsByAddressesEntry
+func ConvertDomainOutpointEntryPairsToUTXOsByAddressesEntries(address string, pairs []*externalapi.OutpointAndUTXOEntryPair) []*appmessage.UTXOsByAddressesEntry {
 	utxosByAddressesEntries := make([]*appmessage.UTXOsByAddressesEntry, 0, len(pairs))
-	for outpoint, utxoEntry := range pairs {
+	for _, outpointAndUTXOEntryPair := range pairs {
 		utxosByAddressesEntries = append(utxosByAddressesEntries, &appmessage.UTXOsByAddressesEntry{
 			Address: address,
 			Outpoint: &appmessage.RPCOutpoint{
-				TransactionID: outpoint.TransactionID.String(),
-				Index:         outpoint.Index,
+				TransactionID: outpointAndUTXOEntryPair.Outpoint.TransactionID.String(),
+				Index:         outpointAndUTXOEntryPair.Outpoint.Index,
 			},
 			UTXOEntry: &appmessage.RPCUTXOEntry{
-				Amount:          utxoEntry.Amount(),
-				ScriptPublicKey: &appmessage.RPCScriptPublicKey{Script: hex.EncodeToString(utxoEntry.ScriptPublicKey().Script), Version: utxoEntry.ScriptPublicKey().Version},
-				BlockDAAScore:   utxoEntry.BlockDAAScore(),
-				IsCoinbase:      utxoEntry.IsCoinbase(),
+				Amount: outpointAndUTXOEntryPair.UTXOEntry.Amount(),
+				ScriptPublicKey: &appmessage.RPCScriptPublicKey{
+					Script:  hex.EncodeToString(outpointAndUTXOEntryPair.UTXOEntry.ScriptPublicKey().Script),
+					Version: outpointAndUTXOEntryPair.UTXOEntry.ScriptPublicKey().Version},
+				BlockDAAScore: outpointAndUTXOEntryPair.UTXOEntry.BlockDAAScore(),
+				IsCoinbase:    outpointAndUTXOEntryPair.UTXOEntry.IsCoinbase(),
 			},
 		})
 	}

--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -462,7 +462,7 @@ func (s *consensus) GetVirtualUTXOs(expectedVirtualParents []*externalapi.Domain
 	return virtualUTXOs, nil
 }
 
-func (s *consensus) FilterUTXOsNotInConsensus(Utxos []*externalapi.OutpointAndUTXOEntryPair) ([]*externalapi.OutpointAndUTXOEntryPair, error) {
+func (s *consensus) FilterOutpointAndUTXOEntryPairsNotInConsensus(Utxos []*externalapi.OutpointAndUTXOEntryPair) ([]*externalapi.OutpointAndUTXOEntryPair, error) {
 
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/domain/consensus/model/externalapi/consensus.go
+++ b/domain/consensus/model/externalapi/consensus.go
@@ -26,7 +26,7 @@ type Consensus interface {
 
 	GetPruningPointUTXOs(expectedPruningPointHash *DomainHash, fromOutpoint *DomainOutpoint, limit int) ([]*OutpointAndUTXOEntryPair, error)
 	GetVirtualUTXOs(expectedVirtualParents []*DomainHash, fromOutpoint *DomainOutpoint, limit int) ([]*OutpointAndUTXOEntryPair, error)
-	FilterUTXOsNotInConsensus(Utxos []*OutpointAndUTXOEntryPair) ([]*OutpointAndUTXOEntryPair, error)
+	FilterOutpointAndUTXOEntryPairsNotInConsensus(Utxos []*OutpointAndUTXOEntryPair) ([]*OutpointAndUTXOEntryPair, error)
 
 	PruningPoint() (*DomainHash, error)
 	PruningPointHeaders() ([]BlockHeader, error)

--- a/domain/consensus/model/externalapi/consensus.go
+++ b/domain/consensus/model/externalapi/consensus.go
@@ -23,8 +23,11 @@ type Consensus interface {
 	GetHashesBetween(lowHash, highHash *DomainHash, maxBlocks uint64) (hashes []*DomainHash, actualHighHash *DomainHash, err error)
 	GetAnticone(blockHash, contextHash *DomainHash, maxBlocks uint64) (hashes []*DomainHash, err error)
 	GetMissingBlockBodyHashes(highHash *DomainHash) ([]*DomainHash, error)
+
 	GetPruningPointUTXOs(expectedPruningPointHash *DomainHash, fromOutpoint *DomainOutpoint, limit int) ([]*OutpointAndUTXOEntryPair, error)
 	GetVirtualUTXOs(expectedVirtualParents []*DomainHash, fromOutpoint *DomainOutpoint, limit int) ([]*OutpointAndUTXOEntryPair, error)
+	FilterUTXOsNotInConsensus(Utxos []*OutpointAndUTXOEntryPair) ([]*OutpointAndUTXOEntryPair, error)
+
 	PruningPoint() (*DomainHash, error)
 	PruningPointHeaders() ([]BlockHeader, error)
 	PruningPointAndItsAnticone() ([]*DomainHash, error)


### PR DESCRIPTION
Check to see if utxos supplied by the utxoindex is also found in the consensusState (which is used by the mempool) before sending rpc responses pertaining to the utxos.

This is a hacky PR that might solve the orphan problem (I still need testnet access to acually test it), if this were to fix the orphan problem, it none-the-less would not fix the underlying issue of utxoindex and consensusState not being in sync about utxos. 

Also the code might require a clean-up, and it fails some tests, for reasons i do not know. 