### PR TITLE
BuildParents and ValidateHeaderInContext improvement

### DIFF
--- a/domain/consensus/model/interface_processes_blockparentbuilder.go
+++ b/domain/consensus/model/interface_processes_blockparentbuilder.go
@@ -6,6 +6,5 @@ import "github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 // a given set of direct parents
 type BlockParentBuilder interface {
 	BuildParents(stagingArea *StagingArea,
-		daaScore uint64,
 		directParentHashes []*externalapi.DomainHash) ([]externalapi.BlockLevelParents, error)
 }

--- a/domain/consensus/processes/blockbuilder/block_builder.go
+++ b/domain/consensus/processes/blockbuilder/block_builder.go
@@ -193,7 +193,7 @@ func (bb *blockBuilder) buildHeader(stagingArea *model.StagingArea, transactions
 		return nil, err
 	}
 
-	parents, err := bb.newBlockParents(stagingArea, daaScore)
+	parents, err := bb.newBlockParents(stagingArea)
 	if err != nil {
 		return nil, err
 	}
@@ -240,12 +240,12 @@ func (bb *blockBuilder) buildHeader(stagingArea *model.StagingArea, transactions
 	), nil
 }
 
-func (bb *blockBuilder) newBlockParents(stagingArea *model.StagingArea, daaScore uint64) ([]externalapi.BlockLevelParents, error) {
+func (bb *blockBuilder) newBlockParents(stagingArea *model.StagingArea) ([]externalapi.BlockLevelParents, error) {
 	virtualBlockRelations, err := bb.blockRelationStore.BlockRelation(bb.databaseContext, stagingArea, model.VirtualBlockHash)
 	if err != nil {
 		return nil, err
 	}
-	return bb.blockParentBuilder.BuildParents(stagingArea, daaScore, virtualBlockRelations.Parents)
+	return bb.blockParentBuilder.BuildParents(stagingArea, virtualBlockRelations.Parents)
 }
 
 func (bb *blockBuilder) newBlockTime(stagingArea *model.StagingArea) (int64, error) {

--- a/domain/consensus/processes/blockbuilder/test_block_builder.go
+++ b/domain/consensus/processes/blockbuilder/test_block_builder.go
@@ -83,7 +83,7 @@ func (bb *testBlockBuilder) buildUTXOInvalidHeader(stagingArea *model.StagingAre
 		return nil, err
 	}
 
-	parents, err := bb.blockParentBuilder.BuildParents(stagingArea, daaScore, parentHashes)
+	parents, err := bb.blockParentBuilder.BuildParents(stagingArea, parentHashes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Do not copy direct parent hashes in BuildParents;
Get ghostdagData only once in ValidateHeaderInContext;
Remove unused daaScore in BuildParents;
Typo in checkHeaderBlueScore;
