### PR TITLE
Add wallet daemon state messages to a terminal window log

### DIFF
--- a/cmd/kaspawallet/daemon/server/server.go
+++ b/cmd/kaspawallet/daemon/server/server.go
@@ -2,11 +2,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"net"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 
 	"github.com/kaspanet/kaspad/util/txmass"
 
@@ -52,18 +53,20 @@ func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath stri
 
 	listener, err := net.Listen("tcp", listen)
 	if err != nil {
-		return (errors.Wrapf(err, "Error listening to tcp at %s", listen))
+		return (errors.Wrapf(err, "Error listening to TCP on %s", listen))
 	}
-	log.Infof("Listening on %s", listen)
+	log.Infof("Listening to TCP on %s", listen)
 
+	log.Infof("Connecting to a node at %s...", rpcServer)
 	rpcClient, err := connectToRPC(params, rpcServer)
 	if err != nil {
 		return (errors.Wrapf(err, "Error connecting to RPC server %s", rpcServer))
 	}
 
+	log.Infof("Connected, reading keys file %s...", keysFilePath)
 	keysFile, err := keys.ReadKeysFile(params, keysFilePath)
 	if err != nil {
-		return (errors.Wrapf(err, "Error connecting to RPC server %s", rpcServer))
+		return (errors.Wrapf(err, "Error reading keys file %s", keysFilePath))
 	}
 
 	serverInstance := &server{
@@ -78,6 +81,7 @@ func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath stri
 		usedOutpoints:       map[externalapi.DomainOutpoint]time.Time{},
 	}
 
+	log.Infof("Read, syncing the wallet...")
 	spawn("serverInstance.sync", func() {
 		err := serverInstance.sync()
 		if err != nil {

--- a/cmd/kaspawallet/daemon/server/server.go
+++ b/cmd/kaspawallet/daemon/server/server.go
@@ -38,6 +38,10 @@ type server struct {
 	addressSet          walletAddressSet
 	txMassCalculator    *txmass.Calculator
 	usedOutpoints       map[externalapi.DomainOutpoint]time.Time
+
+	isLogFinalProgressLineShown bool
+	maxUsedAddressesForLog      uint32
+	maxProcessedAddressesForLog uint32
 }
 
 // Start starts the kaspawalletd server
@@ -70,15 +74,18 @@ func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath stri
 	}
 
 	serverInstance := &server{
-		rpcClient:           rpcClient,
-		params:              params,
-		utxosSortedByAmount: []*walletUTXO{},
-		nextSyncStartIndex:  0,
-		keysFile:            keysFile,
-		shutdown:            make(chan struct{}),
-		addressSet:          make(walletAddressSet),
-		txMassCalculator:    txmass.NewCalculator(params.MassPerTxByte, params.MassPerScriptPubKeyByte, params.MassPerSigOp),
-		usedOutpoints:       map[externalapi.DomainOutpoint]time.Time{},
+		rpcClient:                   rpcClient,
+		params:                      params,
+		utxosSortedByAmount:         []*walletUTXO{},
+		nextSyncStartIndex:          0,
+		keysFile:                    keysFile,
+		shutdown:                    make(chan struct{}),
+		addressSet:                  make(walletAddressSet),
+		txMassCalculator:            txmass.NewCalculator(params.MassPerTxByte, params.MassPerScriptPubKeyByte, params.MassPerSigOp),
+		usedOutpoints:               map[externalapi.DomainOutpoint]time.Time{},
+		isLogFinalProgressLineShown: false,
+		maxUsedAddressesForLog:      0,
+		maxProcessedAddressesForLog: 0,
 	}
 
 	log.Infof("Read, syncing the wallet...")

--- a/cmd/kaspawallet/daemon/server/sync.go
+++ b/cmd/kaspawallet/daemon/server/sync.go
@@ -16,7 +16,7 @@ type walletAddressSet map[string]*walletAddress
 
 var (
 	isProgressLogFinalLineShown bool   = false
-	maxAddressesProcessedForLog uint32 = 0
+	maxProcessedAddressesForLog uint32 = 0
 	maxUsedAddressesForLog      uint32 = 0
 )
 
@@ -284,25 +284,25 @@ func (s *server) isSynced() bool {
 	return s.nextSyncStartIndex > s.keysFile.LastUsedInternalIndex() && s.nextSyncStartIndex > s.keysFile.LastUsedExternalIndex()
 }
 
-func (s *server) updateSyncingProgressLog(currAddressesProcessed, currMaxUsedAddresses uint32) {
+func (s *server) updateSyncingProgressLog(currProcessedAddresses, currMaxUsedAddresses uint32) {
 	if currMaxUsedAddresses > maxUsedAddressesForLog {
 		maxUsedAddressesForLog = currMaxUsedAddresses
 		isProgressLogFinalLineShown = false
 	}
 
-	if currAddressesProcessed > maxAddressesProcessedForLog {
-		maxAddressesProcessedForLog = currAddressesProcessed
+	if currProcessedAddresses > maxProcessedAddressesForLog {
+		maxProcessedAddressesForLog = currProcessedAddresses
 	}
 
-	if maxAddressesProcessedForLog >= maxUsedAddressesForLog {
+	if maxProcessedAddressesForLog >= maxUsedAddressesForLog {
 		if !isProgressLogFinalLineShown {
 			log.Infof("Wallet is synced, ready for queries")
 			isProgressLogFinalLineShown = true
 		}
 	} else {
-		percentProcessed := float64(maxAddressesProcessedForLog) / float64(maxUsedAddressesForLog) * 100.0
+		percentProcessed := float64(maxProcessedAddressesForLog) / float64(maxUsedAddressesForLog) * 100.0
 
 		log.Infof("Gathering UTXOs set, %d addresses of %d processed (%.2f%%)...",
-			maxAddressesProcessedForLog, maxUsedAddressesForLog, percentProcessed)
+			maxProcessedAddressesForLog, maxUsedAddressesForLog, percentProcessed)
 	}
 }


### PR DESCRIPTION
Aimed to clarify to the user the state and operational progress of the wallet daemon as it starts: shows launch process stages and UTXO set gathering progress, updating the info as the new addresses appear in the derived chain