### PR TITLE
Unite multiple `GetBlockAcceptanceData` consensus calls to one

### DIFF
--- a/app/rpc/rpccontext/chain_changed.go
+++ b/app/rpc/rpccontext/chain_changed.go
@@ -40,16 +40,18 @@ func (ctx *Context) getAndConvertAcceptedTransactionIDs(selectedParentChainChang
 
 	acceptedTransactionIDs := make([]*appmessage.AcceptedTransactionIDs, len(selectedParentChainChanges.Added))
 
+	chainBlocksAcceptanceData, err := ctx.Domain.Consensus().GetBlocksAcceptanceData(selectedParentChainChanges.Added)
+	if err != nil {
+		return nil, err
+	}
+
 	for i, addedChainBlock := range selectedParentChainChanges.Added {
-		blockAcceptanceData, err := ctx.Domain.Consensus().GetBlockAcceptanceData(addedChainBlock)
-		if err != nil {
-			return nil, err
-		}
+		chainBlockAcceptanceData := chainBlocksAcceptanceData[i]
 		acceptedTransactionIDs[i] = &appmessage.AcceptedTransactionIDs{
 			AcceptingBlockHash:     addedChainBlock.String(),
 			AcceptedTransactionIDs: nil,
 		}
-		for _, blockAcceptanceData := range blockAcceptanceData {
+		for _, blockAcceptanceData := range chainBlockAcceptanceData {
 			for _, transactionAcceptanceData := range blockAcceptanceData.TransactionAcceptanceData {
 				if transactionAcceptanceData.IsAccepted {
 					acceptedTransactionIDs[i].AcceptedTransactionIDs =

--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -426,6 +426,30 @@ func (s *consensus) GetBlockAcceptanceData(blockHash *externalapi.DomainHash) (e
 	return s.acceptanceDataStore.Get(s.databaseContext, stagingArea, blockHash)
 }
 
+func (s *consensus) GetBlocksAcceptanceData(blockHashes []*externalapi.DomainHash) ([]externalapi.AcceptanceData, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	stagingArea := model.NewStagingArea()
+	acceptanceData := make([]externalapi.AcceptanceData, len(blockHashes))
+
+	for i, blockHash := range blockHashes {
+		err := s.validateBlockHashExists(stagingArea, blockHash)
+		if err != nil {
+			return nil, err
+		}
+
+		blockData, err := s.acceptanceDataStore.Get(s.databaseContext, stagingArea, blockHash)
+		if err != nil {
+			return nil, err
+		}
+
+		acceptanceData[i] = blockData
+	}
+
+	return acceptanceData, nil
+}
+
 func (s *consensus) GetHashesBetween(lowHash, highHash *externalapi.DomainHash, maxBlocks uint64) (
 	hashes []*externalapi.DomainHash, actualHighHash *externalapi.DomainHash, err error) {
 

--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -431,7 +431,7 @@ func (s *consensus) GetBlocksAcceptanceData(blockHashes []*externalapi.DomainHas
 	defer s.lock.Unlock()
 
 	stagingArea := model.NewStagingArea()
-	acceptanceData := make([]externalapi.AcceptanceData, len(blockHashes))
+	blocksAcceptanceData := make([]externalapi.AcceptanceData, len(blockHashes))
 
 	for i, blockHash := range blockHashes {
 		err := s.validateBlockHashExists(stagingArea, blockHash)
@@ -439,15 +439,15 @@ func (s *consensus) GetBlocksAcceptanceData(blockHashes []*externalapi.DomainHas
 			return nil, err
 		}
 
-		blockData, err := s.acceptanceDataStore.Get(s.databaseContext, stagingArea, blockHash)
+		acceptanceData, err := s.acceptanceDataStore.Get(s.databaseContext, stagingArea, blockHash)
 		if err != nil {
 			return nil, err
 		}
 
-		acceptanceData[i] = blockData
+		blocksAcceptanceData[i] = acceptanceData
 	}
 
-	return acceptanceData, nil
+	return blocksAcceptanceData, nil
 }
 
 func (s *consensus) GetHashesBetween(lowHash, highHash *externalapi.DomainHash, maxBlocks uint64) (

--- a/domain/consensus/model/externalapi/consensus.go
+++ b/domain/consensus/model/externalapi/consensus.go
@@ -19,6 +19,7 @@ type Consensus interface {
 	GetBlockInfo(blockHash *DomainHash) (*BlockInfo, error)
 	GetBlockRelations(blockHash *DomainHash) (parents []*DomainHash, children []*DomainHash, err error)
 	GetBlockAcceptanceData(blockHash *DomainHash) (AcceptanceData, error)
+	GetBlocksAcceptanceData(blockHashes []*DomainHash) ([]AcceptanceData, error)
 
 	GetHashesBetween(lowHash, highHash *DomainHash, maxBlocks uint64) (hashes []*DomainHash, actualHighHash *DomainHash, err error)
 	GetAnticone(blockHash, contextHash *DomainHash, maxBlocks uint64) (hashes []*DomainHash, err error)


### PR DESCRIPTION
It is preferred to reduce the number of times consensus lock is acquired during consensus event processing. This should create a better balance between the consensus-event-channel producer (consensus code triggered by inserting blocks and resolving virtual), and the channel consumer (event processing loop). 

My tests show that this change reduces the max channel length from ~2000 to ~500 (during a full IBD and with `includeAcceptedTransactionIDs` listeners)

Note that number of blocks which will be passed to `GetBlocksAcceptanceData` is implicitly limited by the max number of blocks resolved by virtual in a single call (currently 100).