### PR TITLE
Fix `not in selected chain` crash 

### DIFF
--- a/domain/consensus/model/testapi/test_consensus.go
+++ b/domain/consensus/model/testapi/test_consensus.go
@@ -47,6 +47,7 @@ type TestConsensus interface {
 
 	AddUTXOInvalidBlock(parentHashes []*externalapi.DomainHash) (*externalapi.DomainHash,
 		*externalapi.VirtualChangeSet, error)
+	UpdatePruningPointByVirtual() error
 
 	MineJSON(r io.Reader, blockType MineJSONBlockType) (tips []*externalapi.DomainHash, err error)
 	ToJSON(w io.Writer) error

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -191,6 +191,46 @@ func (pm *pruningManager) UpdatePruningPointByVirtual(stagingArea *model.Staging
 	return nil
 }
 
+type blockIteratorFromOneBlock struct {
+	done, isClosed bool
+	hash           *externalapi.DomainHash
+}
+
+func (b *blockIteratorFromOneBlock) First() bool {
+	if b.isClosed {
+		panic("Tried using a closed blockIteratorFromOneBlock")
+	}
+
+	b.done = false
+	return true
+}
+
+func (b *blockIteratorFromOneBlock) Next() bool {
+	if b.isClosed {
+		panic("Tried using a closed blockIteratorFromOneBlock")
+	}
+
+	b.done = true
+	return false
+}
+
+func (b *blockIteratorFromOneBlock) Get() (*externalapi.DomainHash, error) {
+	if b.isClosed {
+		panic("Tried using a closed blockIteratorFromOneBlock")
+	}
+
+	return b.hash, nil
+}
+
+func (b *blockIteratorFromOneBlock) Close() error {
+	if b.isClosed {
+		panic("Tried using a closed blockIteratorFromOneBlock")
+	}
+
+	b.isClosed = true
+	return nil
+}
+
 func (pm *pruningManager) nextPruningPointAndCandidateByBlockHash(stagingArea *model.StagingArea,
 	blockHash, suggestedLowHash *externalapi.DomainHash) (*externalapi.DomainHash, *externalapi.DomainHash, error) {
 
@@ -227,10 +267,6 @@ func (pm *pruningManager) nextPruningPointAndCandidateByBlockHash(stagingArea *m
 		return nil, nil, err
 	}
 
-	if blockHash.Equal(lowHash) {
-		return currentPruningPoint, currentCandidate, nil
-	}
-
 	ghostdagData, err := pm.ghostdagDataStore.Get(pm.databaseContext, stagingArea, blockHash, false)
 	if err != nil {
 		return nil, nil, err
@@ -244,9 +280,14 @@ func (pm *pruningManager) nextPruningPointAndCandidateByBlockHash(stagingArea *m
 	// We iterate until the selected parent of the given block, in order to allow a situation where the given block hash
 	// belongs to the virtual. This shouldn't change anything since the max blue score difference between a block and its
 	// selected parent is K, and K << pm.pruningDepth.
-	iterator, err := pm.dagTraversalManager.SelectedChildIterator(stagingArea, ghostdagData.SelectedParent(), lowHash, true)
-	if err != nil {
-		return nil, nil, err
+	var iterator model.BlockIterator
+	if blockHash.Equal(lowHash) {
+		iterator = &blockIteratorFromOneBlock{hash: lowHash}
+	} else {
+		iterator, err = pm.dagTraversalManager.SelectedChildIterator(stagingArea, ghostdagData.SelectedParent(), lowHash, true)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	defer iterator.Close()
 

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -222,12 +222,16 @@ func (pm *pruningManager) nextPruningPointAndCandidateByBlockHash(stagingArea *m
 		}
 	}
 
-	ghostdagData, err := pm.ghostdagDataStore.Get(pm.databaseContext, stagingArea, blockHash, false)
+	currentPruningPoint, err := pm.pruningStore.PruningPoint(pm.databaseContext, stagingArea)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	currentPruningPoint, err := pm.pruningStore.PruningPoint(pm.databaseContext, stagingArea)
+	if blockHash.Equal(lowHash) {
+		return currentPruningPoint, currentCandidate, nil
+	}
+
+	ghostdagData, err := pm.ghostdagDataStore.Get(pm.databaseContext, stagingArea, blockHash, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/domain/consensus/test_consensus.go
+++ b/domain/consensus/test_consensus.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/kaspanet/kaspad/domain/consensus/model"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/hashset"
+	"github.com/kaspanet/kaspad/util/staging"
 	"io"
 
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
@@ -257,4 +258,17 @@ func (tc *testConsensus) BuildHeaderWithParents(parentHashes []*externalapi.Doma
 	defer tc.lock.Unlock()
 
 	return tc.testBlockBuilder.BuildUTXOInvalidHeader(parentHashes)
+}
+
+func (tc *testConsensus) UpdatePruningPointByVirtual() error {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
+
+	stagingArea := model.NewStagingArea()
+	err := tc.pruningManager.UpdatePruningPointByVirtual(stagingArea)
+	if err != nil {
+		return err
+	}
+
+	return staging.CommitAllChanges(tc.databaseContext, stagingArea)
 }


### PR DESCRIPTION
This PR fixes issue #2073. The crash was in the case where virtual selected parent is the pruning point (happens only when a node restarts following a full IBD with pruning proof, during the block body download phase). 

The selected chain iterator is initialized with high hash selected parent which in this case is a chain parent of low hash and not a chain descendent.  

The suggested fix is to return in this case, since pruning point and/or pruning candidate will not advance any way.  