### PR TITLE
Add RPC timeout parameter to wallet daemon

### DIFF
--- a/cmd/kaspaminer/client.go
+++ b/cmd/kaspaminer/client.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"time"
+
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/kaspanet/kaspad/infrastructure/logger"
 	"github.com/kaspanet/kaspad/infrastructure/network/rpcclient"
 	"github.com/pkg/errors"
-	"time"
 )
 
 const minerTimeout = 10 * time.Second

--- a/cmd/kaspaminer/client.go
+++ b/cmd/kaspaminer/client.go
@@ -23,7 +23,7 @@ func (mc *minerClient) connect() error {
 	if err != nil {
 		return err
 	}
-	rpcClient, err := rpcclient.NewRPCClient(rpcAddress)
+	rpcClient, err := rpcclient.NewRPCClient(rpcAddress, 0)
 	if err != nil {
 		return err
 	}

--- a/cmd/kaspawallet/config.go
+++ b/cmd/kaspawallet/config.go
@@ -111,7 +111,8 @@ type startDaemonConfig struct {
 	KeysFile  string `long:"keys-file" short:"f" description:"Keys file location (default: ~/.kaspawallet/keys.json (*nix), %USERPROFILE%\\AppData\\Local\\Kaspawallet\\key.json (Windows))"`
 	Password  string `long:"password" short:"p" description:"Wallet password"`
 	RPCServer string `long:"rpcserver" short:"s" description:"RPC server to connect to"`
-	Listen    string `short:"l" long:"listen" description:"Address to listen on (default: 0.0.0.0:8082)"`
+	Listen    string `long:"listen" short:"l" description:"Address to listen on (default: 0.0.0.0:8082)"`
+	Timeout   uint32 `long:"wait-timeout" short:"w" description:"Waiting timeout for RPC calls, seconds (default: 30 s)"`
 	Profile   string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
 	config.NetworkFlags
 }
@@ -181,7 +182,6 @@ func parseCommandLine() (subCommand string, config interface{}) {
 	parser.AddCommand(startDaemonSubCmd, "Start the wallet daemon", "Start the wallet daemon", startDaemonConf)
 
 	_, err := parser.Parse()
-
 	if err != nil {
 		var flagsErr *flags.Error
 		if ok := errors.As(err, &flagsErr); ok && flagsErr.Type == flags.ErrHelp {

--- a/cmd/kaspawallet/daemon/server/rpc.go
+++ b/cmd/kaspawallet/daemon/server/rpc.go
@@ -1,15 +1,26 @@
 package server
 
 import (
+	"time"
+
 	"github.com/kaspanet/kaspad/domain/dagconfig"
 	"github.com/kaspanet/kaspad/infrastructure/network/rpcclient"
 )
 
-func connectToRPC(params *dagconfig.Params, rpcServer string) (*rpcclient.RPCClient, error) {
+func connectToRPC(params *dagconfig.Params, rpcServer string, timeout uint32) (*rpcclient.RPCClient, error) {
 	rpcAddress, err := params.NormalizeRPCServerAddress(rpcServer)
 	if err != nil {
 		return nil, err
 	}
 
-	return rpcclient.NewRPCClient(rpcAddress)
+	rpcClient, err := rpcclient.NewRPCClient(rpcAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	if timeout != 0 {
+		rpcClient.SetTimeout(time.Second * time.Duration(timeout))
+	}
+
+	return rpcClient, err
 }

--- a/cmd/kaspawallet/daemon/server/server.go
+++ b/cmd/kaspawallet/daemon/server/server.go
@@ -45,7 +45,7 @@ type server struct {
 }
 
 // Start starts the kaspawalletd server
-func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath string, profile string) error {
+func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath string, profile string, timeout uint32) error {
 	initLog(defaultLogFile, defaultErrLogFile)
 
 	defer panics.HandlePanic(log, "MAIN", nil)
@@ -62,7 +62,7 @@ func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath stri
 	log.Infof("Listening to TCP on %s", listen)
 
 	log.Infof("Connecting to a node at %s...", rpcServer)
-	rpcClient, err := connectToRPC(params, rpcServer)
+	rpcClient, err := connectToRPC(params, rpcServer, timeout)
 	if err != nil {
 		return (errors.Wrapf(err, "Error connecting to RPC server %s", rpcServer))
 	}

--- a/cmd/kaspawallet/start_daemon.go
+++ b/cmd/kaspawallet/start_daemon.go
@@ -3,5 +3,5 @@ package main
 import "github.com/kaspanet/kaspad/cmd/kaspawallet/daemon/server"
 
 func startDaemon(conf *startDaemonConfig) error {
-	return server.Start(conf.NetParams(), conf.Listen, conf.RPCServer, conf.KeysFile, conf.Profile)
+	return server.Start(conf.NetParams(), conf.Listen, conf.RPCServer, conf.KeysFile, conf.Profile, conf.Timeout)
 }

--- a/infrastructure/network/rpcclient/rpcclient.go
+++ b/infrastructure/network/rpcclient/rpcclient.go
@@ -1,6 +1,9 @@
 package rpcclient
 
 import (
+	"sync/atomic"
+	"time"
+
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/kaspanet/kaspad/infrastructure/logger"
 	routerpkg "github.com/kaspanet/kaspad/infrastructure/network/netadapter/router"
@@ -8,8 +11,6 @@ import (
 	"github.com/kaspanet/kaspad/util/panics"
 	"github.com/kaspanet/kaspad/version"
 	"github.com/pkg/errors"
-	"sync/atomic"
-	"time"
 )
 
 const defaultTimeout = 30 * time.Second
@@ -28,7 +29,7 @@ type RPCClient struct {
 	timeout time.Duration
 }
 
-// NewRPCClient creates a new RPC client
+// NewRPCClient сreates a new RPC client with a default call timeout value
 func NewRPCClient(rpcAddress string) (*RPCClient, error) {
 	rpcClient := &RPCClient{
 		rpcAddress: rpcAddress,

--- a/stability-tests/common/rpc/rpc.go
+++ b/stability-tests/common/rpc/rpc.go
@@ -36,7 +36,7 @@ func ConnectToRPC(config *Config, dagParams *dagconfig.Params) (*Client, error) 
 	if err != nil {
 		return nil, err
 	}
-	rpcClient, err := rpcclient.NewRPCClient(rpcAddress)
+	rpcClient, err := rpcclient.NewRPCClient(rpcAddress, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/stability-tests/daa/daa_test.go
+++ b/stability-tests/daa/daa_test.go
@@ -1,24 +1,27 @@
 package daa
 
 import (
+	"math"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/kaspanet/kaspad/domain/consensus/model/externalapi"
 	"github.com/kaspanet/kaspad/domain/consensus/utils/pow"
 	"github.com/kaspanet/kaspad/domain/dagconfig"
 	"github.com/kaspanet/kaspad/infrastructure/network/rpcclient"
 	"github.com/kaspanet/kaspad/stability-tests/common"
-	"math"
-	"math/rand"
-	"os"
-	"testing"
-	"time"
 )
 
-const rpcAddress = "localhost:9000"
-const miningAddress = "kaspadev:qrcqat6l9zcjsu7swnaztqzrv0s7hu04skpaezxk43y4etj8ncwfkuhy0zmax"
-const blockRateDeviationThreshold = 0.5
-const averageBlockRateSampleSize = 60
-const averageHashRateSampleSize = 100_000
+const (
+	rpcAddress                  = "localhost:9000"
+	miningAddress               = "kaspadev:qrcqat6l9zcjsu7swnaztqzrv0s7hu04skpaezxk43y4etj8ncwfkuhy0zmax"
+	blockRateDeviationThreshold = 0.5
+	averageBlockRateSampleSize  = 60
+	averageHashRateSampleSize   = 100_000
+)
 
 func TestDAA(t *testing.T) {
 	if os.Getenv("RUN_STABILITY_TESTS") == "" {
@@ -175,8 +178,8 @@ func measureMachineHashNanoseconds(t *testing.T) int64 {
 }
 
 func runDAATest(t *testing.T, testName string, runDuration time.Duration,
-	targetHashNanosecondsFunction func(totalElapsedDuration time.Duration) int64) {
-
+	targetHashNanosecondsFunction func(totalElapsedDuration time.Duration) int64,
+) {
 	t.Logf("DAA TEST STARTED: %s", testName)
 	defer t.Logf("DAA TEST FINISHED: %s", testName)
 
@@ -264,8 +267,8 @@ func fetchBlockForMining(t *testing.T, rpcClient *rpcclient.RPCClient) *external
 }
 
 func waitUntilTargetHashDurationHadElapsed(startTime time.Time, hashStartTime time.Time,
-	targetHashNanosecondsFunction func(totalElapsedDuration time.Duration) int64) {
-
+	targetHashNanosecondsFunction func(totalElapsedDuration time.Duration) int64,
+) {
 	// Yielding a thread in Go takes up to a few milliseconds whereas hashing once
 	// takes a few hundred nanoseconds, so we spin in place instead of e.g. calling time.Sleep()
 	for {
@@ -279,8 +282,8 @@ func waitUntilTargetHashDurationHadElapsed(startTime time.Time, hashStartTime ti
 
 func logMinedBlockStatsAndUpdateStatFields(t *testing.T, rpcClient *rpcclient.RPCClient,
 	averageMiningDuration *averageDuration, averageHashDurations *averageDuration,
-	startTime time.Time, miningDuration time.Duration, previousDifficulty *float64, blocksMined *int) {
-
+	startTime time.Time, miningDuration time.Duration, previousDifficulty *float64, blocksMined *int,
+) {
 	averageMiningDurationAsDuration := averageMiningDuration.toDuration()
 	averageHashNanoseconds := averageHashDurations.toDuration().Nanoseconds()
 	averageHashesPerSecond := hashNanosecondsToHashesPerSecond(averageHashNanoseconds)

--- a/stability-tests/daa/daa_test.go
+++ b/stability-tests/daa/daa_test.go
@@ -186,7 +186,7 @@ func runDAATest(t *testing.T, testName string, runDuration time.Duration,
 	tearDownKaspad := common.RunKaspadForTesting(t, "kaspad-daa-test", rpcAddress)
 	defer tearDownKaspad()
 
-	rpcClient, err := rpcclient.NewRPCClient(rpcAddress)
+	rpcClient, err := rpcclient.NewRPCClient(rpcAddress, 0)
 	if err != nil {
 		t.Fatalf("NewRPCClient: %s", err)
 	}

--- a/stability-tests/mempool-limits/main_test.go
+++ b/stability-tests/mempool-limits/main_test.go
@@ -1,12 +1,13 @@
 package mempoollimits
 
 import (
+	"os"
+	"testing"
+
 	"github.com/kaspanet/kaspad/infrastructure/network/rpcclient"
 	"github.com/kaspanet/kaspad/stability-tests/common"
 	"github.com/kaspanet/kaspad/util/panics"
 	"github.com/kaspanet/kaspad/util/profiling"
-	"os"
-	"testing"
 )
 
 const (

--- a/stability-tests/mempool-limits/main_test.go
+++ b/stability-tests/mempool-limits/main_test.go
@@ -74,7 +74,7 @@ func TestMempoolLimits(t *testing.T) {
 }
 
 func buildRPCClient(t *testing.T) *rpcclient.RPCClient {
-	client, err := rpcclient.NewRPCClient(activeConfig().KaspadRPCAddress)
+	client, err := rpcclient.NewRPCClient(activeConfig().KaspadRPCAddress, 0)
 	if err != nil {
 		t.Fatalf("error connecting to %s: %s", activeConfig().KaspadRPCAddress, err)
 	}

--- a/testing/integration/rpc_test.go
+++ b/testing/integration/rpc_test.go
@@ -1,10 +1,10 @@
 package integration
 
 import (
-	"github.com/kaspanet/kaspad/infrastructure/config"
 	"testing"
 	"time"
 
+	"github.com/kaspanet/kaspad/infrastructure/config"
 	"github.com/kaspanet/kaspad/infrastructure/network/rpcclient"
 )
 

--- a/testing/integration/rpc_test.go
+++ b/testing/integration/rpc_test.go
@@ -15,7 +15,7 @@ type testRPCClient struct {
 }
 
 func newTestRPCClient(rpcAddress string) (*testRPCClient, error) {
-	rpcClient, err := rpcclient.NewRPCClient(rpcAddress)
+	rpcClient, err := rpcclient.NewRPCClient(rpcAddress, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
PR provided as a response to the observed RPC call timeout panic of kaspawallet daemon that happened with a testnet wallet having a huge amount of UTXOs. 

Also address decoding operation in unsigned transaction creation procedure is moved several lines higher to increase the responsiveness of the wallet (so to precede the UTXO refreshment operation that takes a long time under the same testnet wallet condition, yet is a complete waste of time if the address is incorrect).

Certain tidying of the code, performed automatically by a VisualStudio Code.