### PR TITLE
Add RPC timeout parameter to wallet daemon

### DIFF
--- a/cmd/kaspawallet/config.go
+++ b/cmd/kaspawallet/config.go
@@ -111,7 +111,8 @@ type startDaemonConfig struct {
 	KeysFile  string `long:"keys-file" short:"f" description:"Keys file location (default: ~/.kaspawallet/keys.json (*nix), %USERPROFILE%\\AppData\\Local\\Kaspawallet\\key.json (Windows))"`
 	Password  string `long:"password" short:"p" description:"Wallet password"`
 	RPCServer string `long:"rpcserver" short:"s" description:"RPC server to connect to"`
-	Listen    string `short:"l" long:"listen" description:"Address to listen on (default: 0.0.0.0:8082)"`
+	Listen    string `long:"listen" short:"l" description:"Address to listen on (default: 0.0.0.0:8082)"`
+	Timeout   uint32 `long:"wait-timeout" short:"w" description:"Waiting timeout for RPC calls, seconds (default: 30 s)"`
 	Profile   string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
 	config.NetworkFlags
 }
@@ -181,7 +182,6 @@ func parseCommandLine() (subCommand string, config interface{}) {
 	parser.AddCommand(startDaemonSubCmd, "Start the wallet daemon", "Start the wallet daemon", startDaemonConf)
 
 	_, err := parser.Parse()
-
 	if err != nil {
 		var flagsErr *flags.Error
 		if ok := errors.As(err, &flagsErr); ok && flagsErr.Type == flags.ErrHelp {

--- a/cmd/kaspawallet/daemon/server/rpc.go
+++ b/cmd/kaspawallet/daemon/server/rpc.go
@@ -1,15 +1,26 @@
 package server
 
 import (
+	"time"
+
 	"github.com/kaspanet/kaspad/domain/dagconfig"
 	"github.com/kaspanet/kaspad/infrastructure/network/rpcclient"
 )
 
-func connectToRPC(params *dagconfig.Params, rpcServer string) (*rpcclient.RPCClient, error) {
+func connectToRPC(params *dagconfig.Params, rpcServer string, timeout uint32) (*rpcclient.RPCClient, error) {
 	rpcAddress, err := params.NormalizeRPCServerAddress(rpcServer)
 	if err != nil {
 		return nil, err
 	}
 
-	return rpcclient.NewRPCClient(rpcAddress)
+	rpcClient, err := rpcclient.NewRPCClient(rpcAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	if timeout != 0 {
+		rpcClient.SetTimeout(time.Duration(timeout) * time.Second)
+	}
+
+	return rpcClient, err
 }

--- a/cmd/kaspawallet/daemon/server/server.go
+++ b/cmd/kaspawallet/daemon/server/server.go
@@ -45,7 +45,7 @@ type server struct {
 }
 
 // Start starts the kaspawalletd server
-func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath string, profile string) error {
+func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath string, profile string, timeout uint32) error {
 	initLog(defaultLogFile, defaultErrLogFile)
 
 	defer panics.HandlePanic(log, "MAIN", nil)
@@ -62,7 +62,7 @@ func Start(params *dagconfig.Params, listen, rpcServer string, keysFilePath stri
 	log.Infof("Listening to TCP on %s", listen)
 
 	log.Infof("Connecting to a node at %s...", rpcServer)
-	rpcClient, err := connectToRPC(params, rpcServer)
+	rpcClient, err := connectToRPC(params, rpcServer, timeout)
 	if err != nil {
 		return (errors.Wrapf(err, "Error connecting to RPC server %s", rpcServer))
 	}

--- a/cmd/kaspawallet/start_daemon.go
+++ b/cmd/kaspawallet/start_daemon.go
@@ -3,5 +3,5 @@ package main
 import "github.com/kaspanet/kaspad/cmd/kaspawallet/daemon/server"
 
 func startDaemon(conf *startDaemonConfig) error {
-	return server.Start(conf.NetParams(), conf.Listen, conf.RPCServer, conf.KeysFile, conf.Profile)
+	return server.Start(conf.NetParams(), conf.Listen, conf.RPCServer, conf.KeysFile, conf.Profile, conf.Timeout)
 }

--- a/infrastructure/network/rpcclient/rpcclient.go
+++ b/infrastructure/network/rpcclient/rpcclient.go
@@ -1,6 +1,9 @@
 package rpcclient
 
 import (
+	"sync/atomic"
+	"time"
+
 	"github.com/kaspanet/kaspad/app/appmessage"
 	"github.com/kaspanet/kaspad/infrastructure/logger"
 	routerpkg "github.com/kaspanet/kaspad/infrastructure/network/netadapter/router"
@@ -8,8 +11,6 @@ import (
 	"github.com/kaspanet/kaspad/util/panics"
 	"github.com/kaspanet/kaspad/version"
 	"github.com/pkg/errors"
-	"sync/atomic"
-	"time"
 )
 
 const defaultTimeout = 30 * time.Second
@@ -28,7 +29,7 @@ type RPCClient struct {
 	timeout time.Duration
 }
 
-// NewRPCClient creates a new RPC client
+// NewRPCClient сreates a new RPC client with a default call timeout value
 func NewRPCClient(rpcAddress string) (*RPCClient, error) {
 	rpcClient := &RPCClient{
 		rpcAddress: rpcAddress,


### PR DESCRIPTION
Rewritten. PR provided as a response to the observed RPC call timeout panic of kaspawallet daemon that happened with a testnet wallet having a huge amount of UTXOs.

Also address decoding operation in unsigned transaction creation procedure is moved several lines higher to increase the responsiveness of the wallet (so to precede the UTXO refreshment operation that takes a long time under the same testnet wallet condition, yet is a complete waste of time if the address is incorrect).

Certain tidying of the code, performed automatically by a VisualStudio Code.
