### PR TITLE
Allow mismatched versioning connections with rpc_client

### DIFF
--- a/infrastructure/network/rpcclient/rpcclient.go
+++ b/infrastructure/network/rpcclient/rpcclient.go
@@ -72,7 +72,7 @@ func (c *RPCClient) connect() error {
 	remoteVersion := getInfoResponse.ServerVersion
 
 	if localVersion != remoteVersion {
-		return errors.Errorf("Server version mismatch, expect: %s, got: %s", localVersion, remoteVersion)
+		log.Warnf("version mismatch, client: %s, server: %s - expected responses and requests may deviate", localVersion, remoteVersion)
 	}
 
 	return nil


### PR DESCRIPTION
replace error with a warning when client and server versions are mismatched.