### PR TITLE
Update version.go

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const validCharacters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrs
 const (
 	appMajor uint = 0
 	appMinor uint = 12
-	appPatch uint = 8
+	appPatch uint = 9
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
Since version 0.12.9 was released, shouldn't the version in this file correspond to the alleged version?
Was unsure, but when running my node it was apparent to me that the reported version is inconsistent.

