### PR TITLE
Fix IBD bug

### DIFF
--- a/app/protocol/flows/v5/blockrelay/ibd_with_headers_proof.go
+++ b/app/protocol/flows/v5/blockrelay/ibd_with_headers_proof.go
@@ -55,12 +55,7 @@ func (flow *handleIBDFlow) shouldSyncAndShouldDownloadHeadersProof(
 
 	var highestSharedBlockFound, isPruningPointInSharedBlockChain bool
 	if highestKnownSyncerChainHash != nil {
-		blockInfo, err := flow.Domain().Consensus().GetBlockInfo(highestKnownSyncerChainHash)
-		if err != nil {
-			return false, false, err
-		}
-
-		highestSharedBlockFound = blockInfo.HasBody()
+		highestSharedBlockFound = true
 		pruningPoint, err := flow.Domain().Consensus().PruningPoint()
 		if err != nil {
 			return false, false, err


### PR DESCRIPTION
Fixes IBD bug where if the highest shared block is header-only syncing simply exists.
This can possibly be fixed in a better way, depending on the reason for the change in the first place. 