### PR TITLE
Fix duplicated kaspaminer help output

### DIFF
--- a/cmd/kaspaminer/config.go
+++ b/cmd/kaspaminer/config.go
@@ -48,6 +48,11 @@ func parseConfig() (*configFlags, error) {
 	parser := flags.NewParser(cfg, flags.PrintErrors|flags.HelpFlag)
 	_, err := parser.Parse()
 
+	// If special error ErrHelp catched by -h or --help
+	if ourErr, ok := err.(*flags.Error); ok && ourErr.Type == flags.ErrHelp {
+		os.Exit(0)
+	}
+
 	// Show the version and exit if the version flag was specified.
 	if cfg.ShowVersion {
 		appName := filepath.Base(os.Args[0])
@@ -78,7 +83,8 @@ func parseConfig() (*configFlags, error) {
 	}
 
 	if cfg.MiningAddr == "" {
-		return nil, errors.New("--miningaddr is required")
+		fmt.Fprintln(os.Stderr, errors.New("Error parsing command-line arguments: --miningaddr is required"))
+		os.Exit(1)
 	}
 
 	initLog(defaultLogFile, defaultErrLogFile)


### PR DESCRIPTION
Even if `kaspaminer` isn't widely used anymore, it has some glitches with its command line argument processing. In Karlsen we still rely on the built-in miner and fixed it.

**First issue:** If `./kaspaminer -h` is used, it shows the help twice and a Go trace at the end.

```
$ ./kaspaminer -h
Usage:
  kaspaminer [OPTIONS]

Application Options:
  -V, --version                   Display version information and exit
  -s, --rpcserver=                RPC server to connect to (default: localhost)
      --miningaddr=               Address to mine to
  -n, --numblocks=                Number of blocks to mine. If omitted, will mine until the process is interrupted.
      --mine-when-not-synced      Mine even if the node is not synced with the rest of the network.
      --profile=                  Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536
      --target-blocks-per-second= Sets a maximum block rate. 0 means no limit (The default one is 2 * target network block rate)
      --testnet                   Use the test network
      --simnet                    Use the simulation test network
      --devnet                    Use the development test network
      --override-dag-params-file= Overrides DAG params (allowed only on devnet)

Help Options:
  -h, --help                      Show this help message

Error parsing command-line arguments: Usage:
  kaspaminer [OPTIONS]

Application Options:
  -V, --version                   Display version information and exit
  -s, --rpcserver=                RPC server to connect to (default: localhost)
      --miningaddr=               Address to mine to
  -n, --numblocks=                Number of blocks to mine. If omitted, will mine until the process is interrupted.
      --mine-when-not-synced      Mine even if the node is not synced with the rest of the network.
      --profile=                  Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536
      --target-blocks-per-second= Sets a maximum block rate. 0 means no limit (The default one is 2 * target network block rate)
      --testnet                   Use the test network
      --simnet                    Use the simulation test network
      --devnet                    Use the development test network
      --override-dag-params-file= Overrides DAG params (allowed only on devnet)

Help Options:
  -h, --help                      Show this help message

main.main
	/home/lemois/kaspad/cmd/kaspaminer/main.go:26
runtime.main
	/usr/lib/go/src/runtime/proc.go:271
runtime.goexit
	/usr/lib/go/src/runtime/asm_amd64.s:1695
```

**Second issue:** If `./kaspaminer` is executed without any argument, it shows correct error message but still a Go trace.

```
$ ./kaspaminer 
Error parsing command-line arguments: --miningaddr is required
main.main
	/home/lemois/kaspad/cmd/kaspaminer/main.go:26
runtime.main
	/usr/lib/go/src/runtime/proc.go:271
runtime.goexit
	/usr/lib/go/src/runtime/asm_amd64.s:1695
```

Both issues are fixed with this pull request. For reference, downstream issues: https://github.com/karlsen-network/karlsend/issues/34 and https://github.com/karlsen-network/karlsend/issues/38