### PR TITLE
Remove duplicated decoded address check in 'TestAddresses'

### DIFF
--- a/util/address_test.go
+++ b/util/address_test.go
@@ -361,12 +361,6 @@ func TestAddresses(t *testing.T) {
 				test.name)
 			return
 		}
-
-		if !reflect.DeepEqual(addr, decoded) {
-			t.Errorf("%v: created address does not match the decoded address",
-				test.name)
-			return
-		}
 	}
 }
 


### PR DESCRIPTION
Removed the duplicated decoded address check in `util/address_test.go`. It is enough to check it ones.