### PR TITLE
Fix unbuffered OS signal channel in wallet password input

### DIFF
--- a/cmd/kaspawallet/keys/get_password.go
+++ b/cmd/kaspawallet/keys/get_password.go
@@ -19,7 +19,7 @@ func GetPassword(prompt string) string {
 
 	// Restore it in the event of an interrupt.
 	// CITATION: Konstantin Shaposhnikov - https://groups.google.com/forum/#!topic/golang-nuts/kTVAbtee9UA
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, os.Kill)
 	go func() {
 		<-c


### PR DESCRIPTION
## Summary

In `cmd/kaspawallet/keys/get_password.go:22`, `make(chan os.Signal)` creates an unbuffered channel. The Go documentation explicitly warns:

> *Package signal will not block sending to c: the caller must ensure that c has sufficient buffer space to keep up with the expected signal rate.*

### Risk
If a SIGINT/SIGKILL arrives before the goroutine is ready to receive, the signal sender blocks indefinitely. Under rare timing conditions, pressing Ctrl+C during wallet password entry could be silently dropped, leaving the terminal in a broken raw mode state (no echo, no line buffering).

### Fix
Changed to `make(chan os.Signal, 1)` — a buffer of size 1 ensures the signal notification is never dropped and the goroutine sending the signal never blocks.