### PR TITLE
Fix interface/implementation mismatch for ValidateAndInsertTransaction

### DIFF
--- a/app/protocol/flowcontext/transactions.go
+++ b/app/protocol/flowcontext/transactions.go
@@ -14,7 +14,7 @@ func (f *FlowContext) AddTransaction(tx *externalapi.DomainTransaction) error {
 	f.transactionsToRebroadcastLock.Lock()
 	defer f.transactionsToRebroadcastLock.Unlock()
 
-	err := f.Domain().MiningManager().ValidateAndInsertTransaction(tx, false)
+	err := f.Domain().MiningManager().ValidateAndInsertTransaction(tx, 0, false)
 	if err != nil {
 		return err
 	}

--- a/app/protocol/flows/transactionrelay/handle_relayed_transactions.go
+++ b/app/protocol/flows/transactionrelay/handle_relayed_transactions.go
@@ -173,7 +173,7 @@ func (flow *handleRelayedTransactionsFlow) receiveTransactions(requestedTransact
 				expectedID, txID)
 		}
 
-		err = flow.Domain().MiningManager().ValidateAndInsertTransaction(tx, true)
+		err = flow.Domain().MiningManager().ValidateAndInsertTransaction(tx, 0, true)
 		if err != nil {
 			ruleErr := &mempool.RuleError{}
 			if !errors.As(err, ruleErr) {

--- a/domain/miningmanager/miningmanager.go
+++ b/domain/miningmanager/miningmanager.go
@@ -13,7 +13,7 @@ type MiningManager interface {
 	AllTransactions() []*consensusexternalapi.DomainTransaction
 	TransactionCount() int
 	HandleNewBlockTransactions(txs []*consensusexternalapi.DomainTransaction) ([]*consensusexternalapi.DomainTransaction, error)
-	ValidateAndInsertTransaction(transaction *consensusexternalapi.DomainTransaction, allowOrphan bool) error
+	ValidateAndInsertTransaction(transaction *consensusexternalapi.DomainTransaction, expirationDAAScore uint64, allowOrphan bool) error
 	RevalidateTransaction(tx *consensusexternalapi.DomainTransaction) (isValid bool, err error)
 }
 
@@ -35,8 +35,8 @@ func (mm *miningManager) HandleNewBlockTransactions(txs []*consensusexternalapi.
 // ValidateAndInsertTransaction validates the given transaction, and
 // adds it to the set of known transactions that have not yet been
 // added to any block
-func (mm *miningManager) ValidateAndInsertTransaction(transaction *consensusexternalapi.DomainTransaction, allowOrphan bool) error {
-	return mm.mempool.ValidateAndInsertTransaction(transaction, allowOrphan)
+func (mm *miningManager) ValidateAndInsertTransaction(transaction *consensusexternalapi.DomainTransaction, expirationDAAScore uint64, allowOrphan bool) error {
+	return mm.mempool.ValidateAndInsertTransaction(transaction, expirationDAAScore, allowOrphan)
 }
 
 func (mm *miningManager) GetTransaction(

--- a/domain/miningmanager/miningmanager_test.go
+++ b/domain/miningmanager/miningmanager_test.go
@@ -37,7 +37,7 @@ func TestValidateAndInsertTransaction(t *testing.T) {
 		transactionsToInsert := make([]*externalapi.DomainTransaction, 10)
 		for i := range transactionsToInsert {
 			transactionsToInsert[i] = createTransactionWithUTXOEntry(t, i)
-			err = miningManager.ValidateAndInsertTransaction(transactionsToInsert[i], true)
+			err = miningManager.ValidateAndInsertTransaction(transactionsToInsert[i], 0, true)
 			if err != nil {
 				t.Fatalf("ValidateAndInsertTransaction: %v", err)
 			}
@@ -60,7 +60,7 @@ func TestValidateAndInsertTransaction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error in createParentAndChildrenTransaction: %v", err)
 		}
-		err = miningManager.ValidateAndInsertTransaction(transactionNotAnOrphan, true)
+		err = miningManager.ValidateAndInsertTransaction(transactionNotAnOrphan, 0, true)
 		if err != nil {
 			t.Fatalf("ValidateAndInsertTransaction: %v", err)
 		}
@@ -83,7 +83,7 @@ func TestImmatureSpend(t *testing.T) {
 		miningFactory := miningmanager.NewFactory()
 		miningManager := miningFactory.NewMiningManager(tc, &consensusConfig.Params)
 		tx := createTransactionWithUTXOEntry(t, 0)
-		err = miningManager.ValidateAndInsertTransaction(tx, false)
+		err = miningManager.ValidateAndInsertTransaction(tx, 0, false)
 		txRuleError := &mempool.TxRuleError{}
 		if !errors.As(err, txRuleError) || txRuleError.RejectCode != mempool.RejectImmatureSpend {
 			t.Fatalf("Unexpected error %+v", err)
@@ -110,11 +110,11 @@ func TestInsertDoubleTransactionsToMempool(t *testing.T) {
 		miningFactory := miningmanager.NewFactory()
 		miningManager := miningFactory.NewMiningManager(tc, &consensusConfig.Params)
 		transaction := createTransactionWithUTXOEntry(t, 0)
-		err = miningManager.ValidateAndInsertTransaction(transaction, true)
+		err = miningManager.ValidateAndInsertTransaction(transaction, 0, true)
 		if err != nil {
 			t.Fatalf("ValidateAndInsertTransaction: %v", err)
 		}
-		err = miningManager.ValidateAndInsertTransaction(transaction, true)
+		err = miningManager.ValidateAndInsertTransaction(transaction, 0, true)
 		if err == nil || !strings.Contains(err.Error(), "already have transaction") {
 			t.Fatalf("ValidateAndInsertTransaction: %v", err)
 		}
@@ -138,7 +138,7 @@ func TestHandleNewBlockTransactions(t *testing.T) {
 		for i := range transactionsToInsert {
 			transaction := createTransactionWithUTXOEntry(t, i)
 			transactionsToInsert[i] = transaction
-			err = miningManager.ValidateAndInsertTransaction(transaction, true)
+			err = miningManager.ValidateAndInsertTransaction(transaction, 0, true)
 			if err != nil {
 				t.Fatalf("ValidateAndInsertTransaction: %v", err)
 			}
@@ -201,7 +201,7 @@ func TestDoubleSpends(t *testing.T) {
 		miningFactory := miningmanager.NewFactory()
 		miningManager := miningFactory.NewMiningManager(tc, &consensusConfig.Params)
 		transactionInTheMempool := createTransactionWithUTXOEntry(t, 0)
-		err = miningManager.ValidateAndInsertTransaction(transactionInTheMempool, true)
+		err = miningManager.ValidateAndInsertTransaction(transactionInTheMempool, 0, true)
 		if err != nil {
 			t.Fatalf("ValidateAndInsertTransaction: %v", err)
 		}
@@ -239,7 +239,7 @@ func TestOrphanTransactions(t *testing.T) {
 			t.Fatalf("Error in createArraysOfParentAndChildrenTransactions: %v", err)
 		}
 		for _, orphanTransaction := range childTransactions {
-			err = miningManager.ValidateAndInsertTransaction(orphanTransaction, true)
+			err = miningManager.ValidateAndInsertTransaction(orphanTransaction, 0, true)
 			if err != nil {
 				t.Fatalf("ValidateAndInsertTransaction: %v", err)
 			}

--- a/domain/miningmanager/model/interface_mempool.go
+++ b/domain/miningmanager/model/interface_mempool.go
@@ -9,7 +9,7 @@ import (
 type Mempool interface {
 	HandleNewBlockTransactions(txs []*consensusexternalapi.DomainTransaction) ([]*consensusexternalapi.DomainTransaction, error)
 	BlockCandidateTransactions() []*consensusexternalapi.DomainTransaction
-	ValidateAndInsertTransaction(transaction *consensusexternalapi.DomainTransaction, allowOrphan bool) error
+	ValidateAndInsertTransaction(transaction *consensusexternalapi.DomainTransaction, expirationDAAScore uint64, allowOrphan bool) error
 	RemoveTransactions(txs []*consensusexternalapi.DomainTransaction) error
 	GetTransaction(transactionID *consensusexternalapi.DomainTransactionID) (*consensusexternalapi.DomainTransaction, bool)
 	AllTransactions() []*consensusexternalapi.DomainTransaction


### PR DESCRIPTION
## Summary

The `mempool.go` implementation of `ValidateAndInsertTransaction` was refactored to accept an additional `expirationDAAScore uint64` parameter, but the `Mempool` interface definition was not updated to match.

### Root cause
Go's type system enforces strict interface compliance. The `*mempool` type implemented:
```go
ValidateAndInsertTransaction(*externalapi.DomainTransaction, uint64, bool)
```
but the interface declared:
```go
ValidateAndInsertTransaction(*externalapi.DomainTransaction, bool)
```

### Effect
Branch would not compile: `*mempool does not implement model.Mempool (wrong type for method ValidateAndInsertTransaction)`.

### Files changed
1. `domain/miningmanager/model/interface_mempool.go` — Added `expirationDAAScore uint64` to interface
2. `domain/miningmanager/miningmanager.go` — Updated interface + implementation + delegate call
3. `app/protocol/flowcontext/transactions.go` — Pass `0` for `expirationDAAScore`
4. `app/protocol/flows/transactionrelay/handle_relayed_transactions.go` — Pass `0` for `expirationDAAScore`
5. `domain/miningmanager/miningmanager_test.go` — All 8 calls updated